### PR TITLE
Add requirement for "NoCloud" datasource

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The [samples directory](https://github.com/karmab/kcli/tree/master/samples) cont
 
 ##templates
 
-For templates to work with cloud-init, they require the "NoCloud" datasource to be enabled! Typically configured in /etc/cloud/cloud.cfg.d/90\*.
+For templates to work with cloud-init, they require the "NoCloud" datasource to be enabled! Enable the datasource in the cloud-init configuration. For debian-based systems, you can find this configuration in `/etc/cloud/cloud.cfg.d/90\*`.
 
 Templates should be in the same storage pool as the VM, in order to benefit from the Copy-on-Write mechanism.
 
@@ -179,10 +179,12 @@ virsh vol-create-as vms $TEMPLATE $TSIZE
 virsh vol-upload --pool vms $TEMPLATE ${TEMPLATE}.raw
 ```
 
+Note that disks based on a LVM template always have the same size as the template disk! The code above creates a template-disk that is only just big enough to match the size of the (raw) template. You may want to grow this disk to a reasonable size before creating VM's that use it! Alternatively, you can set the TSIZE parameter above to a static value, rather than using the size of the image.
+
 ##cloudinit stuff
 
 if cloudinit is enabled (it is by default), a custom iso is generated on the fly for your vm ( using mkisofs) and uploaded to your kvm instance ( using the API).
-the iso handles static networking configuration, hostname setting, inyecting ssh keys and running specific commands
+The iso handles static networking configuration, hostname setting, injecting ssh keys and running specific commands
 
 Also note that if you use cloudinit but dont specify ssh keys to inject, the default ~/.ssh/id_rsa.pub will be used, if present.
 
@@ -283,8 +285,7 @@ basic testing can be run with pytest. If using a remote hypervisor, you ll want 
 
 ## issues found with cloud images
 
-- Also note that you need to install python-simplejson ( actually bringing python2.7) to allow ansible to work on ubuntu
-- debian images are freezing. rebooting fixes the issue but as such cloudinit doesnt get applied...
+- Note that you need to install python-simplejson (actually bringing python2.7) to allow ansible to work on ubuntu
 - debian/archlinux images are missing the NoCloud datasource for cloud-init. Edit them with guestfish to make them work with cloud-init.
 
 ## TODO 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ The [samples directory](https://github.com/karmab/kcli/tree/master/samples) cont
 
 ##templates
 
+For templates to work with cloud-init, they require the "NoCloud" datasource to be enabled! Typically configured in /etc/cloud/cloud.cfg.d/90\*.
+
 Templates should be in the same storage pool as the VM, in order to benefit from the Copy-on-Write mechanism.
 
 For a regular file-backed storage pool, download the image you want, and put it in the backing store directory.
@@ -283,6 +285,7 @@ basic testing can be run with pytest. If using a remote hypervisor, you ll want 
 
 - Also note that you need to install python-simplejson ( actually bringing python2.7) to allow ansible to work on ubuntu
 - debian images are freezing. rebooting fixes the issue but as such cloudinit doesnt get applied...
+- debian/archlinux images are missing the NoCloud datasource for cloud-init. Edit them with guestfish to make them work with cloud-init.
 
 ## TODO 
  


### PR DESCRIPTION
Added a snippet in templates to show NoCloud datasource requirement for cloud-init, and added the issue for debian/archlinux in the "issues found" block.
