### PR TITLE
Fix issue with invalid empty() call

### DIFF
--- a/extra/klist.py
+++ b/extra/klist.py
@@ -53,7 +53,7 @@ class KcliInventory(object):
             self.inventory = empty()
         # If no groups or vars are present, return an empty inventory.
         else:
-            self.inventory = self.empty()
+            self.inventory = empty()
         print json.dumps(self.inventory)
 
     # Read the command line args passed to the script.


### PR DESCRIPTION
# python inventories/klist.py 
Traceback (most recent call last):
  File "inventories/klist.py", line 112, in <module>
    KcliInventory()
  File "inventories/klist.py", line 57, in __init__
    self.inventory = self.empty()
AttributeError: 'KcliInventory' object has no attribute 'empty'