### PR TITLE
Add ability to specify MAC address in nets dict

### DIFF
--- a/kvirt/__init__.py
+++ b/kvirt/__init__.py
@@ -202,6 +202,9 @@ class Kvirt:
                     nets[index]['ip'] = ip
                 elif 'ip' in nets[index]:
                     ip = nets[index]['ip']
+                mac = None
+                if 'mac' in nets[index]:
+                    mac = "<mac address='%s'/>" % nets[index]['mac']
                 if index == 0 and ip is not None:
                     version = "<entry name='version'>%s</entry>" % ips[0]
             if netname in bridges:
@@ -212,9 +215,10 @@ class Kvirt:
                 print("Invalid network %s.Leaving..." % netname)
             netxml = """%s
                      <interface type='%s'>
+                     %s
                      <source %s='%s'/>
                      <model type='virtio'/>
-                     </interface>""" % (netxml, sourcenet, sourcenet, netname)
+                     </interface>""" % (netxml, sourcenet, mac, sourcenet, netname)
         version = """<sysinfo type='smbios'>
                      <system>
                      %s

--- a/kvirt/__init__.py
+++ b/kvirt/__init__.py
@@ -202,7 +202,7 @@ class Kvirt:
                     nets[index]['ip'] = ip
                 elif 'ip' in nets[index]:
                     ip = nets[index]['ip']
-                mac = None
+                mac = ''
                 if 'mac' in nets[index]:
                     mac = "<mac address='%s'/>" % nets[index]['mac']
                 if index == 0 and ip is not None:


### PR DESCRIPTION
makes it possible to add a `mac: AA:BB:CC:DD:EE:FF` entry in the nets list (allowing one to pre-allocate IP's through DHCP by editing the libvirt network definition - see RFE)