### PR TITLE
changes ips[0] into ip

### DIFF
--- a/kvirt/__init__.py
+++ b/kvirt/__init__.py
@@ -203,7 +203,7 @@ class Kvirt:
                 elif 'ip' in nets[index]:
                     ip = nets[index]['ip']
                 if index == 0 and ip is not None:
-                    version = "<entry name='version'>%s</entry>" % ips[0]
+                    version = "<entry name='version'>%s</entry>" % ip
             if netname in bridges:
                 sourcenet = 'bridge'
             elif netname in networks:


### PR DESCRIPTION
I think this is what was intended, not sure how else to set a static IP for a host. Sadly has various issues in the different images (not working in archlinux, debian takes much longer to boot while waiting for non-existant DHCP, etc.) so I will probably opt for DHCP. Have some idea in regards to that, but will file seperate issue/rfe.

Note that documentation is also missing the 'ip' field definition for the nets dict in the README. Additionally, I stumbled a bit until i realized from the code that a "mask" parameter is mandatory (not "netmask", not missing), so may want to note that too. If it doesn't find one, it defaults to a DHCP cloud-init config.