### PR TITLE
Tuned the Dockerfile, it uses kcli as entrypoint and less space

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,36 +9,36 @@ It will also report IPS for any VM connected to a dhcp-enabled libvirt network a
 
 It started because I switched from ovirt and needed a tool similar to [ovirt.py](https://github.com/karmab/ovirt)
 
-##  Why should i use this instead of vagrant for kvm
+##  Why should I use this instead of vagrant for kvm?
 
-- easy syntax to launch single or multiple VMS
-- cloudinit based customization, not over ssh
-- no need of using custom images, the public ones will do
-- spice/vnc consoles and tcp serial ones
-- to be fair, i' ve only tested the code against kvm, so vagrant is a better
-  option if you' re running on virtualbox o vmware fusion
+- Easy syntax to launch single or multiple VMS
+- Cloudinit based customization, not over ssh
+- No need of using custom images, the public ones will do
+- Spice/VNC consoles and TCP serial ones
+- To be fair, I've only tested the code against kvm, so vagrant is a better
+  option if you're running on Virtualbox o VMWare Fusion
 
-## demo
+## Demo!
 
 [![asciicast](https://asciinema.org/a/3p0cn60p0c0j9wd3hzyrs4m0f.png)](https://asciinema.org/a/3p0cn60p0c0j9wd3hzyrs4m0f?autoplay=1)
 
-## installation
+## Installation
 
-install requirements. you will also need to grab *genisoimage* (or *mkisofs* on OSX) for cloudinit isos to get generated
+1. Install requirements. you will also need to grab *genisoimage* (or *mkisofs* on OSX) for cloudinit isos to get generated
 Console access is based on remote-viewer
-For instance if using a rhel based distribution:
+For instance if using a RHEL based distribution:
 
 ```
 yum -y install gcc libvirt-devel python-devel genisoimage qemu-kvm nmap-ncat python-pip
 ```
 
-If using a debian based distribution:
+If using a Debian based distribution:
 
 ```
 apt-get -y install python-pip pkg-config libvirt-dev genisoimage qemu-kvm netcat libvirt-bin python-dev libyaml-dev
 ```
 
-then you can install from pypi
+2. Install kcli from pypi
 
 ```
 pip install kcli
@@ -46,27 +46,35 @@ pip install kcli
 
 To deploy from templates, grab images at [openstack](http://docs.openstack.org/image-guide/obtain-images.html)
 
-## I use docker, i m cool
+## I use docker, I'm cool
 
-grab latest image
+Pull the latest image:
 
 `docker pull karmab/kcli`
 
-if running locally, launch it with:
+If running locally, launch it with:
 
-`docker run -it -v /var/run/libvirt:/var/run/libvirt -v ~/.ssh:/root/.ssh karmab/kcli /bin/bash`
+`docker run --rm -v /var/run/libvirt:/var/run/libvirt -v ~/.ssh:/root/.ssh karmab/kcli`
 
-if using a remote hypervisor, launch it with a local kcli.yml file pointing to this hypervisor and providing your ssh keys too
+If using a remote hypervisor, launch it with a local kcli.yml file pointing to this hypervisor and providing your ssh keys too
 
-`docker run -ti -v ~/kcli.yml:/root/kcli.yml -v ~/.ssh:/root/.ssh karmab/kcli /bin/bash`
+`docker run --rm -v ~/kcli.yml:/root/kcli.yml -v ~/.ssh:/root/.ssh karmab/kcli`
 
-In both cases, you can also provide a kcli_profiles.yml (and you could also use a  dedicated plan directory)
+In both cases, you can also provide a kcli_profiles.yml (and you could also use a dedicated plan directory)
 
-`docker run -it -v /var/run/libvirt:/var/run/libvirt -v ~/kcli_profiles.yml:/root/kcli_profiles.yml  -v ~/.ssh:/root/.ssh karmab/kcli /bin/bash`
+`docker run --rm -v /var/run/libvirt:/var/run/libvirt -v ~/kcli_profiles.yml:/root/kcli_profiles.yml  -v ~/.ssh:/root/.ssh karmab/kcli`
 
-`docker run -ti -v ~/kcli.yml:/root/kcli.yml -v ~/kcli_profiles.yml:/root/kcli_profiles.yml -v ~/.ssh:/root/.ssh karmab/kcli /bin/bash`
+`docker run --rm -v ~/kcli.yml:/root/kcli.yml -v ~/kcli_profiles.yml:/root/kcli_profiles.yml -v ~/.ssh:/root/.ssh karmab/kcli`
 
-## configuration
+The entrypoint is defined as kcli, so you can type commands directly as:
+
+`docker run --rm -v ~/kcli.yml:/root/kcli.yml -v ~/kcli_profiles.yml:/root/kcli_profiles.yml -v ~/.ssh:/root/.ssh karmab/kcli list`
+
+As a bonus, you can alias kcli and run kcli as if it is installed locally instead a Docker container:
+
+`alias kcli = "docker run --rm -v ~/kcli.yml:/root/kcli.yml -v ~/kcli_profiles.yml:/root/kcli_profiles.yml -v ~/.ssh:/root/.ssh karmab/kcli"`
+
+## Configuration
 
 If you only want to use your local libvirt daemon, no configuration is needed.
 If you want to generate a basic settings file, you can use the following command:
@@ -75,7 +83,7 @@ If you want to generate a basic settings file, you can use the following command
 kcli bootstrap -f
 ```
 
-You can also go through wizard 
+You can also go through wizard
 
 ```
 kcli bootstrap
@@ -84,7 +92,7 @@ kcli bootstrap
 And for advanced bootstrapping, you can specify a target name, host, a pool with a path, and have centos cloud image downloaded
 
 ```
-kcli bootstrap -a -n twix -H 192.168.0.6 --pool vms --poolpath /home/vms -t 
+kcli bootstrap -a -n twix -H 192.168.0.6 --pool vms --poolpath /home/vms -t
 ```
 
 Or even use an existing disk for LVM based images (note that the disk will be made into an LVM physical volume, so it should be empty):
@@ -94,16 +102,19 @@ kcli bootstrap -a -n twix -H 192.168.0.6 --pool vms --poolpath /dev/vdb --poolty
 ```
 
 You can add an additional storage pool with:
+
 ```
 kcli pool -f -t logical -p /dev/sda ssd
 ```
 
 And define additional networks with:
+
 ```
 kcli network -c 10.0.1.0/24 private11 --dhcp
 ```
 
 And download a fedora template:
+
 ```
 kcli download -p vms -t fedora
 ```
@@ -133,10 +144,10 @@ bumblefoot:
  pool: images
 ```
 
-replace with your own client in default section and indicate host and protocol in the corresponding client section.
+Replace with your own client in default section and indicate host and protocol in the corresponding client section.
 Note that most of the parameters are actually optional, and can be overridden in the profile section (or in a plan file)
 
-## profile configuration
+## Profile configuration
 
 You can use the file ~/kcli_profiles.yml to specify profiles (number of CPUS, memory, size of disk, network,....) to use when deploying a VM.
 
@@ -144,52 +155,52 @@ The [samples directory](https://github.com/karmab/kcli/tree/master/samples) cont
 
 ## How to use
 
-- get info on your kvm setup
+- Get info on your kvm setup
  - `kcli report`
-- list VMS, along with their private IP (and plan if applicable)
+- List VMS, along with their private IP (and plan if applicable)
  - `kcli list`
-- list templates (Note that it will find them out based on their qcow2 extension...)
+- List templates (Note that it will find them out based on their qcow2 extension...)
  - `kcli list -t`
-- create VM from profile base7
+- Create VM from profile base7
  - `kcli create -p base7 myvm`
-- delete VM
+- Delete VM
  - `kcli delete vm1`
-- get detailed info on a specific VM
- - `kcli info vm1` 
-- start VM
- - `kcli start vm1` 
-- stop VM
- - `kcli start vm1` 
-- get remote-viewer console
- - `kcli console vm1` 
-- get serial console (over tcp!!!). Note that it will only work with VMS created with kcli and will require netcat client to be installed on host
- - `kcli console -s vm1` 
-- deploy multiple VMS using plan x defined in x.yml file 
+- Get detailed info on a specific VM
+ - `kcli info vm1`
+- Start VM
+ - `kcli start vm1`
+- Stop VM
+ - `kcli start vm1`
+- Get remote-viewer console
+ - `kcli console vm1`
+- Get serial console (over TCP!!!). Note that it will only work with VMS created with kcli and will require netcat client to be installed on host
+ - `kcli console -s vm1`
+- Deploy multiple VMS using plan x defined in x.yml file
  - `kcli plan -f x.yml x`
-- delete all VM from plan x
-  - `kcli plan -d x` 
-- add 5GB disk to vm1, using pool named vms
-  - `kcli disk -s 5 -p vms vm1` 
-- delete disk named vm1_2.img from vm1
-  - `kcli disk -d -n vm1_2.img  vm1` 
-- update to 2GB memory  vm1
-  - `kcli update -m 2048 vm1` 
-- update internal IP (usefull for ansible inventory over existing bridged VMS)
-  - `kcli update -1 192.168.0.40 vm1` 
-- clone vm1 to new vm2
-  - `kcli clone -b vm1 vm2` 
-- connect by ssh to the VM (retrieving IP and adjusting user based on the template)
-  - `kcli ssh vm1` 
-- switch active client to bumblefoot
-  - `kcli switch bumblefoot` 
-- add a new network
-  - `kcli network -c 192.168.7.0/24 --dhcp mynet` 
-- add a new nic from network private1
+- Delete all VM from plan x
+  - `kcli plan -d x`
+- Add 5GB disk to vm1, using pool named vms
+  - `kcli disk -s 5 -p vms vm1`
+- Delete disk named vm1_2.img from vm1
+  - `kcli disk -d -n vm1_2.img  vm1`
+- Update to 2GB memory  vm1
+  - `kcli update -m 2048 vm1`
+- Update internal IP (useful for ansible inventory over existing bridged VMS)
+  - `kcli update -1 192.168.0.40 vm1`
+- Clone vm1 to new vm2
+  - `kcli clone -b vm1 vm2`
+- Connect by ssh to the VM (retrieving IP and adjusting user based on the template)
+  - `kcli ssh vm1`
+- Switch active client to bumblefoot
+  - `kcli switch bumblefoot`
+- Add a new network
+  - `kcli network -c 192.168.7.0/24 --dhcp mynet`
+- Add a new nic from network private1
 - - `kcli nic -n private1 myvm`
-- delete nic eth2 from VM
+- Delete nic eth2 from VM
 - - `kcli nic -di eth2 myvm`
 
-##templates
+## Templates
 
 For templates to work with cloud-init, they require the "NoCloud" datasource to be enabled! Enable the datasource in the cloud-init configuration. For debian-based systems, you can find this configuration in `/etc/cloud/cloud.cfg.d/90\*`.
 
@@ -209,16 +220,16 @@ virsh vol-upload --pool vms $TEMPLATE ${TEMPLATE}.raw
 
 Note that disks based on a LVM template always have the same size as the template disk! The code above creates a template-disk that is only just big enough to match the size of the (raw) template. You may want to grow this disk to a reasonable size before creating VM's that use it! Alternatively, you can set the TSIZE parameter above to a static value, rather than using the size of the image.
 
-##cloudinit stuff
+## Cloudinit stuff
 
-if cloudinit is enabled (it is by default), a custom iso is generated on the fly for your VM (using mkisofs) and uploaded to your kvm instance (using the API).
+If cloudinit is enabled (it is by default), a custom iso is generated on the fly for your VM (using mkisofs) and uploaded to your kvm instance (using the libvirt API, not using ssh commands, pretty cool, huh?).
 The iso handles static networking configuration, hostname setting, injecting ssh keys and running specific commands
 
 Also note that if you use cloudinit but dont specify ssh keys to inject, the default ~/.ssh/id_rsa.pub will be used, if present.
 
 ## Using plans
 
-you can also define plan files in yaml with a list of VMS, disks, and networks and VMS to deploy (look at the sample) and deploy it with kcli plan.
+You can also define plan files in yaml with a list of VMS, disks, and networks and VMS to deploy (look at the sample) and deploy it with kcli plan.
 
 For instance, to define a network named mynet:
 
@@ -227,8 +238,8 @@ mynet:
  type: network
  cidr: 192.168.95.0/24
 ```
-You can also use the boolean keyword dhcp (mostly to disable it) and isolated . Note that when not specified, dhcp and nat will be enabled
 
+You can also use the boolean keyword dhcp (mostly to disable it) and isolated . Note that when not specified, dhcp and nat will be enabled
 
 To define a shared disk named shared1.img between two VMS (that typically would be defined within the same plan):
 
@@ -244,9 +255,9 @@ share1.img:
 
 Regarding VMS, You can point at an existing profile within your plans, define all parameters for the VMS, or combine both approaches.
 
-Specific scripts and IPS arrays can be used directly in the plan file (or in profiles one)
+Specific scripts and IPS arrays can be used directly in the plan file (or in profiles one).
 
-The samples directory contains examples to get you started
+The samples directory contains examples to get you started.
 
 Note that the description of the VM will automatically be set to the plan name, and this value will be used when deleting the entire plan as a way to locate matching VMS.
 
@@ -256,11 +267,11 @@ If a file with the plan isnt specified with -f , the file kcli_plan.yml in the c
 
 Also note that when deleting a plan, the network of the VMS will also be deleted if no other VM are using them. You can prevent this by using the keep (-k) flag
 
-For an advanced use of plans along with scripts, you can check the [plans](plans/README.md) page to deploy all upstream projects associated with Red Hat Cloud Infrastructure products (or downstream versions too)
+For an advanced use of plans along with scripts, you can check the [plans](plans/README.md) page to deploy all upstream projects associated with Red Hat Cloud Infrastructure products (or downstream versions too).
 
-## available parameters
+## Available parameters
 
-those parameters can be set either in your config, profile or plan files
+Those parameters can be set either in your config, profile or plan files
 
 - *numcpus* Defaults to 2
 - *memory* Defaults to 512
@@ -277,8 +288,8 @@ disks:
    thin: False
    format: ide
 ```
-Within a disk section, you can use the word size, thin and format as keys
 
+Within a disk section, you can use the word size, thin and format as keys
 
 - *diskthin* Value used when not specified in the disk entry. Defaults to true
 - *diskinterface* Value used when not specified in the disk entry. Defaults to virtio. Could also be ide, if VM lacks virtio drivers
@@ -293,10 +304,11 @@ nets:
    mask: 255.255.255.0
    gateway: 192.168.0.1
 ```
+
 Within a net section, you can use name, nic, IP, mac, mask and gateway as keys.
 
 Note that up to 8 IPS can also be provided on command line when creating a single VM (with the flag -1, -2, -3,-4,...)
-Also note that if you set reserveip  to True, a reservation will be made if the corresponding network has dhcp and when the provided IP belongs to the network range
+Also note that if you set reserveip  to True, a reservation will be made if the corresponding network has dhcp and when the provided IP belongs to the network range.
 
 - *iso* (optional)
 - *netmasks* (optional)
@@ -312,10 +324,9 @@ Also note that if you set reserveip  to True, a reservation will be made if the 
 - *profile* name of one of your profile. Only checked in plan file
 - *scripts* array of paths of custom script to inject with cloudinit. Note that it will override cmds part. You can either specify full paths or relative to where you're running kcli. Only checked in profile or plan file
 
+## Docker support
 
-## docker support
-
-docker support is mainly enabled as a commodity to launch some containers along vms in plan files. Of course, you will need docker installed on the hypervisor. So the following can be used in a plan file to launch a container:
+Docker support is mainly enabled as a commodity to launch some containers along vms in plan files. Of course, you will need docker installed on the hypervisor. So the following can be used in a plan file to launch a container:
 
 ```
 centos:
@@ -329,7 +340,7 @@ centos:
 ```
 
 The following keywords can be used:
- 
+
 - *image* name of the image to pull ( You can alternatively use the keyword *template*
 - *cmd* command to run within the container
 - *ports* array of ports to map between host and container
@@ -348,13 +359,13 @@ Also note that while python sdk is used when connecting locally, commands are ra
 
 Finally, note that if using the docker version of kcli against your local host , you'll need to pass a docker socket:
 
-`docker run -it -v /var/run/libvirt:/var/run/libvirt -v ~/.ssh:/root/.ssh -v /var/run/docker.sock:/var/run/docker.sock karmab/kcli /bin/bash`
+`docker run --rm -v /var/run/libvirt:/var/run/libvirt -v ~/.ssh:/root/.ssh -v /var/run/docker.sock:/var/run/docker.sock karmab/kcli`
 
-## ansible support
+## Ansible support
 
-you can check klist.py in the extra directory and use it as a dynamic inventory for ansible.
+You can check klist.py in the extra directory and use it as a dynamic inventory for ansible.
 
-The script uses sames conf as kcli (and as such defaults to local hypervisor if no configuration file is found)
+The script uses sames conf as kcli (and as such defaults to local hypervisor if no configuration file is found).
 
 VM will be grouped by plan, or put in the kvirt group if they dont belong to any plan.
 
@@ -364,30 +375,28 @@ Try it with:
 
 ```
 python extra/klist.py --list
-
 ansible all -i extra/klist.py -m ping
 ```
 
-Additionally, there s an ansible kcli/kvirt module under extras, with a sample playbook
+Additionally, there is an ansible kcli/kvirt module under extras, with a sample playbook
 
+## Testing
 
-## testing
+Basic testing can be run with pytest. If using a remote hypervisor, you ll want to set the *KVIRT_HOST* and *KVIRT_USER* environment variables so that it points to your host with the corresponding user.
 
-basic testing can be run with pytest. If using a remote hypervisor, you ll want to set the *KVIRT_HOST* and *KVIRT_USER* environment variables so that it points to your host with the corresponding user.
+## Issues found with cloud images
 
-## issues found with cloud images
+- Note that you need to install python-simplejson (actually bringing python2.7) to allow ansible to work on Ubuntu
+- Debian/Archlinux images are missing the NoCloud datasource for cloud-init. Edit them with guestfish to make them work with cloud-init.
 
-- Note that you need to install python-simplejson (actually bringing python2.7) to allow ansible to work on ubuntu
-- debian/archlinux images are missing the NoCloud datasource for cloud-init. Edit them with guestfish to make them work with cloud-init.
+## TODO
 
-## TODO 
+- Find a way to easily share the plan files (for instance, adding a list of urls in the conf and a fetch subcommand)
+- Remove all the print for the kvirt module and only return data
+- Change the try, except blocks for object checks with parsing of the list methods that libvirt provides for most object
+- Add basic validation of IPS, netmasks, macs,...  within plan file
 
-- find a way to easily share the plan files (for instance, adding a list of urls in the conf and a fetch subcommand)
-- remove all the print for the kvirt module and only return data
-- change the try, except blocks for object checks with parsing of the list methods that libvirt provides for most object
-- add basic validation of IPS, netmasks, macs,...  within plan file
-
-##Problems?
+## Problems?
 
 Send me a mail at [karimboumedhel@gmail.com](mailto:karimboumedhel@gmail.com) !
 

--- a/extras/Dockerfile.centos
+++ b/extras/Dockerfile.centos
@@ -1,7 +1,16 @@
 FROM centos:7
 MAINTAINER Karim Boumedhel <karimboumedhel@gmail.com>
 
-RUN yum -y install epel-release
-RUN yum -y install gcc libvirt-devel python-devel genisoimage qemu-kvm nmap-ncat python-pip openssh-clients
-RUN pip install kcli
-RUN pip install docker
+# Group the package installation
+RUN yum clean all && \
+    yum -y install epel-release && \
+    yum -y install gcc libvirt-devel python-devel genisoimage qemu-kvm nmap-ncat python-pip openssh-clients && \
+    yum clean all
+
+# Group the pip installation
+RUN pip install --no-cache-dir kcli docker
+
+VOLUME ["/var/run/libvirt", "/root/.ssh", "/root"]
+
+ENTRYPOINT ["/usr/bin/kcli"]
+CMD ["-h"]


### PR DESCRIPTION
From 472 MB to 374.8 MB, and to be able to use it as it were installed instead switch to the runing docker container.

Also fixed some capitalization in the Readme file.

Few notes:
* The url parameter is not documented but it is pretty handy to pass custom urls like qemu+ssh://edu@x.y.z:22222/system
* The folder with the kcli code is named kvirt :)

KCLI FTW!!!