### PR TITLE
Detect IPv6 addresses in network reporting and error handling

### DIFF
--- a/kvirt/__init__.py
+++ b/kvirt/__init__.py
@@ -426,8 +426,13 @@ class Kvirt:
                 attributes = ip[0].attrib
                 firstip = attributes.get('address')
                 netmask = attributes.get('netmask')
-                ip = IPNetwork('%s/%s' % (firstip, netmask))
-                cidr = ip.cidr
+                if netmask is None:
+                    netmask = attributes.get('prefix')
+                try:
+                    ip = IPNetwork('%s/%s' % (firstip, netmask))
+                    cidr = ip.cidr
+                except:
+                    cidr = " ** Error getting IP information **"
             dhcp = root.getiterator('dhcp')
             if dhcp:
                 dhcp = True


### PR DESCRIPTION
When using _--report_ option, IPv6 networks break ip/netmask detection as XML is slightly different:
`  <ip family='ipv6' address='2001:db8::2:1' prefix='64'></ip>`

This change tries to get **netmask** attribute and if is missing tries to get **prefix**, instead of detecting **family** which can be a different option to implement it.

Lastly, it catches **IPNetwork** exception to not break reporting.