### PR TITLE
Fixes Ansible Dynamic inventory

### DIFF
--- a/extras/klist.py
+++ b/extras/klist.py
@@ -4,7 +4,7 @@
 ansible dynamic inventory script for use with kcli and libvirt
 '''
 
-from kvirt.kvm import Kvirt
+from kvirt import Kvirt
 import json
 import yaml
 import os


### PR DESCRIPTION
It was not working :(

$ ./klist.py         
Traceback (most recent call last):
  File "./klist.py", line 7, in <module>
    from kvirt.kvm import Kvirt
ImportError: No module named kvm