### PR TITLE
Solving Inventory problems on tower 3.1

### DIFF
--- a/plans/tower/inventory
+++ b/plans/tower/inventory
@@ -18,3 +18,9 @@ pg_port=''
 pg_database='awx'
 pg_username='awx'
 pg_password='unix1234'
+
+rabbitmq_port=5672
+rabbitmq_vhost=tower
+rabbitmq_username=tower
+rabbitmq_password='unix1234'
+rabbitmq_cookie=rabbitmqcookie

--- a/plans/tower/inventory
+++ b/plans/tower/inventory
@@ -1,3 +1,6 @@
+[tower:children]
+primary
+
 [primary]
 localhost ansible_connection=local
 


### PR DESCRIPTION
In Ansible Tower 3.1 change the group name, tower against primary o secondary, this way is compatible with both versions ;)