### PR TITLE
Fix scp.

### DIFF
--- a/kvirt/kvm/__init__.py
+++ b/kvirt/kvm/__init__.py
@@ -1438,7 +1438,7 @@ class Kvirt(Kbase):
                 scpcommand = "%s %s %s@%s:%s %s" % (scpcommand, arguments, user, ip, source, destination)
             else:
                 scpcommand = "%s %s %s %s@%s:%s" % (scpcommand, arguments, source, user, ip, destination)
-            os.system(scpcommand)
+            return scpcommand
 
     def create_pool(self, name, poolpath, pooltype='dir', user='qemu'):
         conn = self.conn


### PR DESCRIPTION
Kvirt.scp should return an scp command (like ssh does) but it was
directly running the scp command and returning None. cli.scp expected
this behavior and was showing an error message.