### PR TITLE
Make directory with full path

### DIFF
--- a/kvirt/common/__init__.py
+++ b/kvirt/common/__init__.py
@@ -65,7 +65,13 @@ def fetch(url, path, syms=None):
         syms = symlinks(user, repo)
         url = url.replace("%s/%s" % (user, repo), "%s/%s/contents" % (user, repo))
     if not os.path.exists(path):
-        os.mkdir(path)
+        try:
+            os.makedirs(path)
+        except OSError as exc:  # Python >2.5
+            if exc.errno == errno.EEXIST and os.path.isdir(path):
+                pass
+            else:
+                raise
     try:
         r = urllib2.urlopen(url)
     except urllib2.HTTPError:


### PR DESCRIPTION
When adding a repo, if .kcli does not exist, it fails with:
$ kcli repo -u github.com/karmab/kcli/plans karmab
Using local hypervisor as no .kcli/config.yml was found...
Adding repo karmab...
Traceback (most recent call last):
  File "/usr/bin/kcli", line 11, in <module>
	load_entry_point('kcli==9.5', 'console_scripts', 'kcli')()
  File "/usr/lib/python2.7/site-packages/kvirt/cli.py", line 1145, in cli
	args.func(args)
  File "/usr/lib/python2.7/site-packages/kvirt/cli.py", line 665, in repo
	config.create_repo(repo, url)
  File "/usr/lib/python2.7/site-packages/kvirt/config.py", line 407, in create_repo
	self.update_repo(name, url=url)
  File "/usr/lib/python2.7/site-packages/kvirt/config.py", line 453, in update_repo
	common.fetch(url, repodir)
  File "/usr/lib/python2.7/site-packages/kvirt/common/init.py", line 66, in fetch
	os.mkdir(path)
OSError: [Errno 2] No such file or directory: '/home/jaramire/.kcli/repo_karmab'
