### PR TITLE
Enables Ansible logs OCP multimaster plan

### DIFF
--- a/plans/openshift/multimaster/install.sh
+++ b/plans/openshift/multimaster/install.sh
@@ -8,6 +8,7 @@ ssh-keyscan -H master03.karmalabs.local >> ~/.ssh/known_hosts
 ssh-keyscan -H node01.karmalabs.local >> ~/.ssh/known_hosts
 ssh-keyscan -H node02.karmalabs.local >> ~/.ssh/known_hosts
 export IP=`ip a l  eth0 | grep 'inet ' | cut -d' ' -f6 | awk -F'/' '{ print $1}'`
+sed -i "s/#log_path/log_path/" /etc/ansible/ansible.cfg
 sed -i "s/openshift_master_default_subdomain=.*/openshift_master_default_subdomain=$IP.xip.io/" /root/hosts
 ansible-playbook -i /root/hosts /usr/share/ansible/openshift-ansible/playbooks/byo/config.yml
 for i in 1 2 3 ; do 


### PR DESCRIPTION
When installing OCP using the multimaster plan, Ansible logs are lost.

Enabling them on /etc/ansible/ansible.cfg, so in case of failure during the installation,
there is a log to check.

By default to /var/log/ansible.log.