### PR TITLE
move node to name on instack definition files, node is ignored

### DIFF
--- a/plans/openstack/tripleo/advanced/instackenv.sh
+++ b/plans/openstack/tripleo/advanced/instackenv.sh
@@ -8,7 +8,7 @@ jq . << EOF > ~/instackenv.json
   "arch": "x86_64",
   "nodes": [
     {
-      "node": "tricontroller01",
+      "name": "tricontroller01",
       "pm_addr": "192.168.101.1",
       "pm_password": "$(cat ~/.ssh/id_rsa_libvirt)",
       "pm_type": "pxe_ssh",
@@ -22,7 +22,7 @@ jq . << EOF > ~/instackenv.json
       "pm_user": "$USER"
     },
     {
-      "node": "tricontroller02",
+      "name": "tricontroller02",
       "pm_addr": "192.168.101.1",
       "pm_password": "$(cat ~/.ssh/id_rsa_libvirt)",
       "pm_type": "pxe_ssh",
@@ -36,7 +36,7 @@ jq . << EOF > ~/instackenv.json
       "pm_user": "$USER"
     },
     {
-      "node": "tricontroller03",
+      "name": "tricontroller03",
       "pm_addr": "192.168.101.1",
       "pm_password": "$(cat ~/.ssh/id_rsa_libvirt)",
       "pm_type": "pxe_ssh",
@@ -50,7 +50,7 @@ jq . << EOF > ~/instackenv.json
       "pm_user": "$USER"
     },
     {
-      "node": "tricompute01",
+      "name": "tricompute01",
       "pm_addr": "192.168.101.1",
       "pm_password": "$(cat ~/.ssh/id_rsa_libvirt)",
       "pm_type": "pxe_ssh",

--- a/plans/openstack/tripleo/advancedceph/instackenv.sh
+++ b/plans/openstack/tripleo/advancedceph/instackenv.sh
@@ -8,7 +8,7 @@ jq . << EOF > ~/instackenv.json
   "arch": "x86_64",
   "nodes": [
     {
-      "node": "tricontroller01",
+      "name": "tricontroller01",
       "pm_addr": "192.168.101.1",
       "pm_password": "$(cat ~/.ssh/id_rsa_libvirt)",
       "pm_type": "pxe_ssh",
@@ -22,7 +22,7 @@ jq . << EOF > ~/instackenv.json
       "pm_user": "$USER"
     },
     {
-      "node": "tricontroller02",
+      "name": "tricontroller02",
       "pm_addr": "192.168.101.1",
       "pm_password": "$(cat ~/.ssh/id_rsa_libvirt)",
       "pm_type": "pxe_ssh",
@@ -36,7 +36,7 @@ jq . << EOF > ~/instackenv.json
       "pm_user": "$USER"
     },
     {
-      "node": "tricontroller03",
+      "name": "tricontroller03",
       "pm_addr": "192.168.101.1",
       "pm_password": "$(cat ~/.ssh/id_rsa_libvirt)",
       "pm_type": "pxe_ssh",
@@ -50,7 +50,7 @@ jq . << EOF > ~/instackenv.json
       "pm_user": "$USER"
     },
     {
-      "node": "tricompute01",
+      "name": "tricompute01",
       "pm_addr": "192.168.101.1",
       "pm_password": "$(cat ~/.ssh/id_rsa_libvirt)",
       "pm_type": "pxe_ssh",
@@ -64,7 +64,7 @@ jq . << EOF > ~/instackenv.json
       "pm_user": "$USER"
     },
     {
-      "node": "triceph01",
+      "name": "triceph01",
       "pm_addr": "192.168.101.1",
       "pm_password": "$(cat ~/.ssh/id_rsa_libvirt)",
       "pm_type": "pxe_ssh",
@@ -78,7 +78,7 @@ jq . << EOF > ~/instackenv.json
       "pm_user": "$USER"
     },
     {
-      "node": "triceph02",
+      "name": "triceph02",
       "pm_addr": "192.168.101.1",
       "pm_password": "$(cat ~/.ssh/id_rsa_libvirt)",
       "pm_type": "pxe_ssh",
@@ -92,7 +92,7 @@ jq . << EOF > ~/instackenv.json
       "pm_user": "$USER"
     },
     {
-      "node": "triceph03",
+      "name": "triceph03",
       "pm_addr": "192.168.101.1",
       "pm_password": "$(cat ~/.ssh/id_rsa_libvirt)",
       "pm_type": "pxe_ssh",

--- a/plans/openstack/tripleo/simple/instackenv.sh
+++ b/plans/openstack/tripleo/simple/instackenv.sh
@@ -8,7 +8,7 @@ jq . << EOF > ~/instackenv.json
   "arch": "x86_64",
   "nodes": [
     {
-      "node": "tricontroller01",
+      "name": "tricontroller01",
       "pm_addr": "192.168.101.1",
       "pm_password": "$(cat ~/.ssh/id_rsa_libvirt)",
       "pm_type": "pxe_ssh",
@@ -22,7 +22,7 @@ jq . << EOF > ~/instackenv.json
       "pm_user": "$USER"
     },
     {
-      "node": "tricompute01",
+      "name": "tricompute01",
       "pm_addr": "192.168.101.1",
       "pm_password": "$(cat ~/.ssh/id_rsa_libvirt)",
       "pm_type": "pxe_ssh",


### PR DESCRIPTION
When using node, the name of the baremetal node is set to None:

$ openstack baremetal node list
+-------------------------+------+---------------+-------------+--------------------+-------------+
| UUID                    | Name | Instance UUID | Power State | Provisioning State | Maintenance |
+-------------------------+------+---------------+-------------+--------------------+-------------+
| abd11301-89cf-4990      | None | None          | power off   | available          | False       |
| -9cef-cff9339a2e47      |      |               |             |                    |             |
| df30f9ce-51ec-43b5      | None | None          | power off   | available          | False       |
| -80bd-44c2ef24a3e9      |      |               |             |                    |             |
| 92c93adc-b704-4a65-ac05 | None | None          | power off   | available          | False       |
| -9072faa3fb81           |      |               |             |                    |             |
| c8ba86dc-ed87-40da-b483 | None | None          | power off   | available          | False       |
| -783ba15c93d3           |      |               |             |                    |             |
+-------------------------+------+---------------+-------------+--------------------+-------------+

When using name as parameter in the json file, the baremetal node is set to the correct value:

$ openstack baremetal node list
+----------------------+------------+---------------+-------------+--------------------+-------------+
| UUID                 | Name       | Instance UUID | Power State | Provisioning State | Maintenance |
+----------------------+------------+---------------+-------------+--------------------+-------------+
| c352d942-731e-4c11-b | controller | None          | power off   | available          | False       |
| b80-1a6619e1bbac     |            |               |             |                    |             |
| 37feb84c-13f5-4787-9 | hyper01    | None          | power off   | available          | False       |
| fe3-26440db6d824     |            |               |             |                    |             |
| 8e6a8cff-2c42-4cdd-  | hyper02    | None          | power off   | available          | False       |
| 850b-517f2f24f6e1    |            |               |             |                    |             |
| 03db2211-aeac-4b24   | hyper03    | None          | power off   | available          | False       |
| -875c-9fd83e12a722   |            |               |             |                    |             |
+----------------------+------------+---------------+-------------+--------------------+-------------+
