### PR TITLE
Add --deletenetworks parameter to force remove networks when deleting a plan

### DIFF
--- a/kvirt/cli.py
+++ b/kvirt/cli.py
@@ -660,6 +660,7 @@ def plan(args):
     start = args.start
     stop = args.stop
     delete = args.delete
+    deletenetworks = args.deletenetworks
     delay = args.delay
     use = args.use
     yes = args.yes
@@ -690,7 +691,7 @@ def plan(args):
         common.confirm("Are you sure?")
     config.plan(plan, ansible=ansible, get=get, path=path, autostart=autostart,
                 container=container, noautostart=noautostart, inputfile=inputfile,
-                start=start, stop=stop, delete=delete, delay=delay, overrides=overrides, info=info)
+                start=start, stop=stop, delete=delete, deletenetworks=deletenetworks, delay=delay, overrides=overrides, info=info)
     return 0
 
 
@@ -1126,6 +1127,8 @@ def cli():
     plan_parser = subparsers.add_parser('plan', description=plan_info, help=plan_info)
     plan_parser.add_argument('-A', '--ansible', help='Generate ansible inventory', action='store_true')
     plan_parser.add_argument('-d', '--delete', action='store_true')
+    plan_parser.add_argument('--deletenetworks', action='store_true', default=0,
+                             help='Delete networks when deleting a plan')
     plan_parser.add_argument('-g', '--get', help='Download specific plan(s).'
                              ' Use --path for specific directory', metavar='URL')
     plan_parser.add_argument('-i', '--info', action='store_true', help='Provide information on the given plan')

--- a/kvirt/config.py
+++ b/kvirt/config.py
@@ -673,7 +673,7 @@ class Kconfig(Kbaseconfig):
         return {'result': 'success', 'plan': plan}
 
     def plan(self, plan, ansible=False, get=None, path=None, autostart=False, container=False, noautostart=False,
-             inputfile=None, start=False, stop=False, delete=False, delay=0, force=True, overrides={}, info=False):
+             inputfile=None, start=False, stop=False, delete=False, deletenetworks=False, delay=0, force=True, overrides={}, info=False):
         """Create/Delete/Stop/Start vms from plan file"""
         k = self.k
         no_overrides = not overrides
@@ -724,10 +724,13 @@ class Kconfig(Kbaseconfig):
                         found = True
             # for network in k.list_networks():
             #    if 'plan' in network and network['plan'] == plan:
-            for network in networks:
-                k.delete_network(network)
-                common.pprint("Unused network %s deleted!" % network, color='green')
-                found = True
+            if deletenetworks:
+                for network in networks:
+                    k.delete_network(network)
+                    common.pprint("Unused network %s deleted!" % network, color='green')
+                    found = True
+            else:
+                common.pprint("Not deleting networks. Delete them manually if required.")
             for keyfile in glob.glob("%s.key*" % plan):
                 common.pprint("file %s from %s deleted!" % (keyfile, plan), color='green')
                 os.remove(keyfile)


### PR DESCRIPTION
Deleting automatically the networks when deleting a plan can be annoying in some scenarios.

With this patch, by default, networks aren't deleted while deleting a plan:
```
$ kcli plan -d -y desperated_karmab
VM ocp311-master01 deleted on local!
VM ocp311-masterlb deleted on local!
VM ocp311-node01 deleted on local!
VM ocp311-node02 deleted on local!
Not deleting networks. Delete them manually if required.
Plan desperated_karmab deleted!
```

I've also included a parameter to force deleting them on-demand:
```
$ kcli plan -d -y --deletenetworks desperated_karmab
VM ocp311-master01 deleted on local!
VM ocp311-masterlb deleted on local!
VM ocp311-node01 deleted on local!
VM ocp311-node02 deleted on local!
Unused network net1 deleted!
Plan desperated_karmab deleted!
```