### PR TITLE
fix typo in Ubuntu 18.04 image download URL

### DIFF
--- a/kvirt/defaults.py
+++ b/kvirt/defaults.py
@@ -70,7 +70,7 @@ TEMPLATES = {'': None, 'arch': 'https://linuximages.de/openstack/arch/arch-opens
              'ubuntu1610': 'https://cloud-images.ubuntu.com/yakkety/current/yakkety-server-cloudimg-amd64-disk1.img',
              'ubuntu1704': 'https://cloud-images.ubuntu.com/zesty/current/zesty-server-cloudimg-amd64.img',
              'ubuntu1710': 'https://cloud-images.ubuntu.com/artful/current/artful-server-cloudimg-amd64.img',
-             'ubuntu1804': 'https://cloud-images.ubuntu.com/bionis/current/bionic-server-cloudimg-amd64.img',
+             'ubuntu1804': 'https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img',
              'ubuntu1810': 'https://cloud-images.ubuntu.com/cosmic/current/cosmic-server-cloudimg-amd64.img'}
 TEMPLATESCOMMANDS = {'cloudforms': 'rm -f /etc/cloud/cloud.cfg.d/30_miq_datasources.cfg',
                      'debian8': 'echo datasource_list: [NoCloud, ConfigDrive, Openstack, Ec2] > /etc/cloud/cloud.cfg.d/'


### PR DESCRIPTION
While attempting to download the Ubuntu Bionic image using kcli v14 I was presented with an error message 

```
$ kcli download ubuntu1804
Using pool default
Grabbing template bionic-server-cloudimg-amd64.img...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Template bionic-server-cloudimg-amd64.img not Added because Unable to download indicated template

$ kcli --version
14.0

```

Sure enough there's a typo on the URL download location for the Bionic image. Instead the download location should be https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img
