### PR TITLE
Typo when kcli console VM in opening remote-viewer

### DIFF
--- a/kvirt/kvm/__init__.py
+++ b/kvirt/kvm/__init__.py
@@ -938,7 +938,7 @@ class Kvirt(object):
                 url = "%s://%s:%s" % (protocol, host, localport)
                 if self.debug:
                     print(url)
-                consolecommand += "; remote-viewer %s &" % url
+                consolecommand += "remote-viewer %s &" % url
                 # os.popen("remote-viewer %s &" % url)
                 os.popen(consolecommand)
 


### PR DESCRIPTION
It seems the'e a typo when kcli console VM in opening remote-viewer

Simple fix for issue https://github.com/karmab/kcli/issues/132