### PR TITLE
Taking into account the tunnel option

### DIFF
--- a/kvirt/kvm/__init__.py
+++ b/kvirt/kvm/__init__.py
@@ -938,7 +938,10 @@ class Kvirt(object):
                 url = "%s://%s:%s" % (protocol, host, localport)
                 if self.debug:
                     print(url)
-                consolecommand += "remote-viewer %s &" % url
+                if tunnel:
+                    consolecommand += "; remote-viewer %s &" % url
+                else:
+                    consolecommand += "remote-viewer %s &" % url
                 # os.popen("remote-viewer %s &" % url)
                 os.popen(consolecommand)
 


### PR DESCRIPTION
It seems the'e a typo when kcli console VM in opening remote-viewer

Simple fix for issue https://github.com/karmab/kcli/issues/132 **AND** having into account the tunnel option