### PR TITLE
Fixed bug avoiding disk additions to current plans

### DIFF
--- a/kvirt/config.py
+++ b/kvirt/config.py
@@ -1234,7 +1234,7 @@ class Kconfig(Kbaseconfig):
                                         pool = self.pool
                                     elif isinstance(disk, dict):
                                         size = disk.get('size', self.disksize)
-                                        diskpool = disk.get('pool', self.pool)
+                                        pool = disk.get('pool', self.pool)
                                     else:
                                         continue
                                     z.add_disk(name=name, size=size, pool=pool)


### PR DESCRIPTION
I was adding a disk to a VM in a current plan I had, which was changin from:

```yaml
satellite:
  template: rhel-server-7.6-x86_64-kvm.qcow2
  numcpus: 2
  memory: 20000
  keys:
    - "ola"
  disks:
    - size: 50
      pool: general_images
  reservedns: true
  nets:
    - name: default
      nic: eth0
      ip: 192.168.122.10
      mask: 255.255.255.0
      gateway: 192.168.122.1
```
To:
```bash
satellite:
  template: rhel-server-7.6-x86_64-kvm.qcow2
  numcpus: 2
  memory: 20000
  keys:
    - "ola"
  disks:
    - size: 50
      pool: general_images
    - size: 50
      pool: general_images
  reservedns: true
  nets:
    - name: default
      nic: eth0
      ip: 192.168.122.10
      mask: 255.255.255.0
      gateway: 192.168.122.1
```

The error I was getting was:

```bash
[sergio@t470swifi personal_cluster]$ kcli plan satellite --update -f infra_satellite.yml                                                                                             [131/131]
Deploying Vms...                                                                                                                                                                              
Adding Disks to satellite                                                                                                                                                                     
Traceback (most recent call last):                                                                                                                                                            
  File "/usr/bin/kcli", line 11, in <module>                                                                                                                                                  
    load_entry_point('kcli==14.7', 'console_scripts', 'kcli')()                                                                                                                               
  File "/usr/lib/python3.7/site-packages/kvirt/cli.py", line 1397, in cli                                                                                                                     
    args.func(args)                                                                                                                                                                           
  File "/usr/lib/python3.7/site-packages/kvirt/cli.py", line 788, in plan                                                                                                                     
    revert=revert, update=update)                                                                                                                                                             
  File "/usr/lib/python3.7/site-packages/kvirt/config.py", line 1235, in plan                                                                                                                 
    z.add_disk(name=name, size=size, pool=pool)                                                                                                                                               
UnboundLocalError: local variable 'pool' referenced before assignment 
```

I changed the name of the variable diskpool, so it assigns the pool name to pool and it works now :)

```bash
[sergio@t470swifi personal_cluster]$ kcli plan satellite --update -f infra_satellite.yml
Deploying Vms...
Adding Disks to satellite
VM satellite_host_rhel6 skipped on cluster!
VM satellite_host_rhel7 skipped on cluster!
VM satellite_host_rhel8 skipped on cluster!
```