### PR TITLE
Add python3-docker to rpm spec

### DIFF
--- a/extras/kcli.spec
+++ b/extras/kcli.spec
@@ -15,7 +15,7 @@ Source:         https://files.pythonhosted.org/packages/source/k/kcli/kcli-%{ver
 AutoReq:        no
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  python3-devel rubygem-ronn gzip
-Requires:       python3 libvirt-python3 genisoimage nmap-ncat python3-prettytable python3-PyYAML python3-flask python3-netaddr
+Requires:       python3 libvirt-python3 genisoimage nmap-ncat python3-prettytable python3-PyYAML python3-flask python3-netaddr python3-docker
 
 %description
 Kcli is meant to interact with a local/remote libvirt, gcp, aws ovirt,


### PR DESCRIPTION
Hi Karim,
Pretty straightforward fix:

```
$ sudo kcli list --images
Traceback (most recent call last):
  File "/usr/bin/kcli", line 11, in <module>
    load_entry_point('kcli==14.13', 'console_scripts', 'kcli')()
  File "/usr/lib/python3.7/site-packages/kvirt/cli.py", line 1404, in cli
    args.func(args)
  File "/usr/lib/python3.7/site-packages/kvirt/cli.py", line 432, in _list
    cont = Kcontainerconfig(config, client=args.containerclient).cont
  File "/usr/lib/python3.7/site-packages/kvirt/containerconfig.py", line 40, in __init__
    from kvirt.docker import Kdocker
  File "/usr/lib/python3.7/site-packages/kvirt/docker/__init__.py", line 7, in <module>
    import docker
ModuleNotFoundError: No module named 'docker'

$ sudo dnf install python3-docker
[...]
Installed:
  python3-docker-3.7.0-1.fc30.noarch                      libsodium-1.0.18-1.fc30.x86_64                       python3-paramiko-2.5.0-1.fc30.noarch          
  python3-bcrypt-3.1.4-7.fc30.x86_64                      python3-docker-pycreds-0.4.0-1.fc30.noarch           python3-pynacl-1.3.0-1.fc30.x86_64            
  python3-websocket-client-0.54.0-1.fc30.noarch          

Complete!
!

$ sudo kcli list --images
+------+--------+-----+--------+------+---------+--------+
| Name | Status | Ips | Source | Plan | Profile | Report |
+------+--------+-----+--------+------+---------+--------+
+------+--------+-----+--------+------+---------+--------+
```
