### PR TITLE
Fix vms listing in web interface when there are vms snapshots

### DIFF
--- a/kvirt/common/__init__.py
+++ b/kvirt/common/__init__.py
@@ -585,12 +585,15 @@ def print_info(yamlinfo, output='plain', fields=[], values=False, pretty=True):
                                                                                                      diskformat,
                                                                                                      drivertype,
                                                                                                      path)
-                        value = disks.rstrip()
+                    value = disks.rstrip()
                 elif key == 'snapshots':
+                    snaps = ''
                     for snap in value:
                         snapshot = snap['snapshot']
                         current = snap['current']
-                        value += "snapshot: %s current: %s" % (snapshot, current)
+                        snaps += "snapshot: %s current: %s\n" % (snapshot, current)
+                    value = snaps.rstrip()
+
                 if values or key in ['disks', 'nets']:
                     result += "%s\n" % value
                 else:


### PR DESCRIPTION
Error when trying to get the list of vms and there are snapshots present. 
Only happen in web interface (not in CLI)

```

[jolmomar@juanmipc kcli]$ kweb
 * Serving Flask app "kvirt.web" (lazy loading)
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: on
 * Running on http://0.0.0.0:9000/ (Press CTRL+C to quit)
 * Restarting with stat
 * Debugger is active!
 * Debugger PIN: 242-472-529
Using local libvirt as no client was specified...
127.0.0.1 - - [08/Nov/2019 16:10:37] "GET / HTTP/1.1" 200 -
Using local libvirt as no client was specified...
127.0.0.1 - - [08/Nov/2019 16:10:37] "GET /vmstable HTTP/1.1" 500 -
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/flask/app.py", line 2463, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/lib/python3.7/site-packages/flask/app.py", line 2449, in wsgi_app
    response = self.handle_exception(e)
  File "/usr/lib/python3.7/site-packages/flask/app.py", line 1866, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/usr/lib/python3.7/site-packages/flask/app.py", line 2446, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/lib/python3.7/site-packages/flask/app.py", line 1951, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/lib/python3.7/site-packages/flask/app.py", line 1820, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/lib/python3.7/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/usr/lib/python3.7/site-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/lib/python3.7/site-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/root/kcli/kvirt/web.py", line 44, in vmstable
    vm['info'] = print_info(vm, output='plain', pretty=True)
  File "/root/kcli/kvirt/common/__init__.py", line 589, in print_info
    snapshot = snap['snapshot']
TypeError: string indices must be integers
127.0.0.1 - - [08/Nov/2019 16:10:37] "GET /static/images/favicon.ico HTTP/1.1" 200 -
```


Signed-off-by: Juan Miguel Olmo Martínez jolmomar@redhat.com