### PR TITLE
Fix shared folder creation in hypervisor

### DIFF
--- a/kvirt/providers/kvm/__init__.py
+++ b/kvirt/providers/kvm/__init__.py
@@ -748,7 +748,9 @@ class Kvirt(object):
                 sharedxml += "</filesystem>"
                 foldercmd = "sudo mkdir %s ; sudo chmod 777 %s" % (folder, folder)
                 if self.host == 'localhost' or self.host == '127.0.0.1' and not os.path.exists(folder):
-                    os.mkdir(foldercmd)
+                    oldmask = os.umask(000)
+                    os.makedirs(folder)
+                    r = os.umask(oldmask)
                 elif self.protocol == 'ssh':
                     foldercmd = 'ssh %s -p %s %s@%s "test -d %s || (%s)"' % (self.identitycommand, self.port,
                                                                              self.user, self.host, folder, foldercmd)


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/bin/kcli", line 11, in <module>
    load_entry_point('kcli', 'console_scripts', 'kcli')()
  File "/root/kcli/kvirt/cli.py", line 2912, in cli
    args.func(args)
  File "/root/kcli/kvirt/cli.py", line 1256, in create_plan
    overrides=overrides, wait=wait)
  File "/root/kcli/kvirt/config.py", line 1515, in plan
    plan=plan, basedir=currentplandir, client=vmclient, onfly=onfly, planmode=True)
  File "/root/kcli/kvirt/config.py", line 725, in create_vm
    pcidevices=pcidevices, tpm=tpm, rng=rng, kube=kube, kubetype=kubetype)
  File "/root/kcli/kvirt/providers/kvm/__init__.py", line 751, in create
    os.mkdir(foldercmd)
FileNotFoundError: [Errno 2] No such file or directory: 'sudo mkdir /home/xxx ; sudo chmod 777 /home/xxx'