### PR TITLE
fix: cpupinning_worker not workers

### DIFF
--- a/kvirt/openshift/kcli_default.yml
+++ b/kvirt/openshift/kcli_default.yml
@@ -54,7 +54,7 @@ numamode_master:
 numamode_worker:
 cpupinning:
 cpupinning_master:
-cpupinning_workers:
+cpupinning_worker:
 disconnected_url:
 disconnected_user:
 disconnected_password:


### PR DESCRIPTION
* Fixes: `Error rendering inputfile /home/sjr/desk/src/kcli/kvirt/openshift/workers.yml. Got: 'cpupinning_worker' is undefined`
* openshift/kcli_default.yml defines cpupinning_workers while
workers.yml or kubeadm/kcli_default.yml define cpupinning_worker.