### PR TITLE
rm extra path on the URL generated in _uploadimage

### DIFF
--- a/kvirt/providers/vsphere/__init__.py
+++ b/kvirt/providers/vsphere/__init__.py
@@ -955,7 +955,7 @@ class Ksphere:
         destination = os.path.basename(origin)
         if temp:
             destination = "temp-%s" % destination
-        url = "https://%s:443/folder/%s/%s?dcPath=%s&dsName=%s" % (self.vcip, directory, destination, self.dc.name,
+        url = "https://%s:443/%s/%s?dcPath=%s&dsName=%s" % (self.vcip, directory, destination, self.dc.name,
                                                                    pool)
         client_cookie = si._stub.cookie
         cookie_name = client_cookie.split("=", 1)[0]


### PR DESCRIPTION
The characters "folder" was part of the generated URL in _uploadimage. This resulted in a HTTP404. Tested on local and KCLI can, after the removal of "folder" in the URL complete the image upload to vSphere.