### PR TITLE
install.sh: fix POSIX conditions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,11 +8,11 @@ NC='\033[0m'
 
 shell=$(basename $SHELL)
 packagefound=false
-if [ $(which dnf) != "" ] ; then 
+if [ "$(which dnf)" != "" ] ; then
   packagefound=true
   sudo dnf -y copr enable karmab/kcli
   sudo dnf -y install kcli
-elif [ $(which apt-get) != "" ] ; then
+elif [ "$(which apt-get)" != "" ] ; then
   packagefound=true
   curl -1sLf https://dl.cloudsmith.io/public/karmab/kcli/cfg/setup/bash.deb.sh | sudo -E bash
   sudo apt-get update 


### PR DESCRIPTION
using single bracket in shell script is the POSIX syntax for conditions.
Therefore, variables must be double-quoted to avoid syntax error when
variables are undefined or empty like following:

bash: line 11: [: !=: unary operator expected

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>