### PR TITLE
Support for all K3s args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,22 @@
+# Folder to ignore
 build/
-*.egg
-*.eggs
-*.egg-info
-*.pyc
-dist
 build
-eggs
-*pyc
-*.key
-*.key.pub
-*retry
-*wiki
-prout.yml
-.DS_Store
 .cache/
+dist
+.DS_Store
+eggs
 kvirt/static/reports/*
 venv*
+
+# Files to ignore
+*.egg
+*.egg-info
+*.eggs
+*pyc
+*.pyc
+*.key
+*.key.pub
+kubectl
+prout.yml
+*retry
+*wiki

--- a/kvirt/config.py
+++ b/kvirt/config.py
@@ -300,7 +300,8 @@ class Kconfig(Kbaseconfig):
         self.overrides.update(config_data)
 
     def create_vm(self, name, profile, overrides={}, customprofile={}, k=None,
-                  plan='kvirt', basedir='.', client=None, onfly=None, wait=False, onlyassets=False):
+                  plan='kvirt', basedir='.', client=None, onfly=None, wait=False,
+                  onlyassets=False, cluster=None):
         """
 
         :param k:
@@ -655,13 +656,23 @@ class Kconfig(Kbaseconfig):
                         os.makedirs(destdir, exist_ok=True)
                     common.fetch("%s/%s" % (onfly, script), destdir)
                 script = os.path.expanduser(script)
-                if basedir != '.':
+                if basedir != '.' and not script.endswith('join.sh'):
                     script = '%s/%s' % (basedir, script)
+                else:
+                    # To support defining cmds in VM rules, in KCLI plan files, when deploying K3s.
+                    # When deploying K3s the join.sh script is generated on the fly
+                    # & contains K3s cluster join info.
+                    # This in comparison to using the `scripts` claus in the workers.yml file
+                    #if script.endswith('join.sh'):
+                    script = os.path.expanduser("~/.kcli/clusters/%s/%s" % (cluster, scriptname))
+                
+                # Final conditionals before templating the lines of the script into cloud-init runcmd 
                 if script.endswith('register.sh') and skip_rhnregister_script:
                     continue
                 elif not os.path.exists(script):
                     return {'result': 'failure', 'reason': "Script %s not found" % script}
                 else:
+                    # Templating the scriptlines into cloud-init runcmd values
                     scriptbasedir = os.path.dirname(script) if os.path.dirname(script) != '' else '.'
                     env = Environment(loader=FileSystemLoader(scriptbasedir), undefined=undefined,
                                       extensions=['jinja2.ext.do'], trim_blocks=True, lstrip_blocks=True)
@@ -1264,7 +1275,7 @@ $INFO
 
     def plan(self, plan, ansible=False, url=None, path=None, container=False, inputfile=None, inputstring=None,
              overrides={}, info=False, update=False, embedded=False, download=False, quiet=False, doc=False,
-             onlyassets=False, pre=True):
+             onlyassets=False, pre=True, cluster=None):
         """Manage plan file"""
         k = self.k
         no_overrides = not overrides
@@ -1556,7 +1567,7 @@ $INFO
                     continue
         if vmentries:
             if not onlyassets:
-                pprint("Deploying Vms...")
+                pprint("Deploying VM's...")
             vmcounter = 0
             hosts = {}
             vms_to_host = {}
@@ -1768,7 +1779,7 @@ $INFO
                         currentoverrides['image'] = profile['image']
                 result = self.create_vm(name, profilename, overrides=currentoverrides, customprofile=profile, k=z,
                                         plan=plan, basedir=currentplandir, client=vmclient, onfly=onfly,
-                                        onlyassets=onlyassets)
+                                        onlyassets=onlyassets, cluster=cluster)
                 if not onlyassets:
                     common.handle_response(result, name, client=vmclient)
                 if result['result'] == 'success':

--- a/kvirt/examples.py
+++ b/kvirt/examples.py
@@ -124,6 +124,9 @@ $ kcli create vm -i centos8 -P disks=['{"size": 10, "interface": "sata"}']
 
 # Create a vm from a custom profile
 $ kcli create vm -p myprofile myvm
+
+# Boot an empty vm from a given iso
+$ kcli create vm -P iso=xxx.iso myvm
 """
 
 vmconsole = """# Open a graphical console for vm ( only shows the command if using container)
@@ -134,7 +137,7 @@ $ kcli console -s myvm
 """
 
 vmexport = """# Export vm myvm with a specific name for the generated image
-$ kcli export -i myimage vmyvm
+$ kcli export -i myimage myvm
 """
 
 kubegenericcreate = """# Create a kube instance named mykube with default values

--- a/kvirt/k3s/bootstrap.sh
+++ b/kvirt/k3s/bootstrap.sh
@@ -1,23 +1,22 @@
 {% set extra_args = [] %}
-{% for component in disabled_components %}
-{% do extra_args.append("--disable " + component) %}
+{% for component in k3s_extra_args_all %}
+{% do extra_args.append(component) %}
+{% endfor %}
+{% for component in k3s_extra_args_masters %}
+{% do extra_args.append(component) %}
 {% endfor %}
 apt-get -y install curl
 {% if masters > 1 %}
-curl -sfL https://get.k3s.io | {{ "INSTALL_K3S_EXEC='--flannel-backend=none'" if sdn != "flannel" else '' }} INSTALL_K3S_CHANNEL={{ install_k3s_channel }} INSTALL_K3S_VERSION={{ install_k3s_version if install_k3s_version != "latest" else '' }} K3S_TOKEN={{ token }} sh -s - server --cluster-init {{ extra_args|join(" ") }}
+curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL={{ install_k3s_channel }} INSTALL_K3S_VERSION={{ install_k3s_version if install_k3s_version != "latest" else '' }} K3S_TOKEN={{ token }} sh -s - server --cluster-init {{ extra_args|join(" ") }}
 export IP={{ api_ip }}
 {% else %}
-curl -sfL https://get.k3s.io | {{ "INSTALL_K3S_EXEC='--flannel-backend=none'" if sdn != "flannel" else '' }} INSTALL_K3S_CHANNEL={{ install_k3s_channel }} INSTALL_K3S_VERSION={{ install_k3s_version if install_k3s_version != "latest" else '' }} K3S_TOKEN={{ token }} sh -s - server {{ extra_args|join(" ") }}
+curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL={{ install_k3s_channel }} INSTALL_K3S_VERSION={{ install_k3s_version if install_k3s_version != "latest" else '' }} K3S_TOKEN={{ token }} sh -s - server {{ extra_args|join(" ") }}
 export IP=$(hostname -I | cut -f1 -d" ")
 {% endif %}
+apt-get -y remove curl
 export K3S_TOKEN=$(cat /var/lib/rancher/k3s/server/node-token)
 sed "s/127.0.0.1/$IP/" /etc/rancher/k3s/k3s.yaml > /root/kubeconfig
 if [ -d /root/manifests ] ; then
  mkdir -p /var/lib/rancher/k3s/server
  mv /root/manifests /var/lib/rancher/k3s/server
 fi
-{% if sdn == 'cilium' %}
-echo bpffs /sys/fs/bpf bpf defaults 0 0 >> /etc/fstab
-mount /sys/fs/bpf
-kubectl create -f https://raw.githubusercontent.com/cilium/cilium/{{ 'cilium/cilium' | githubversion(cilium_version|default('latest')) }}/install/kubernetes/quick-install.yaml
-{% endif %}

--- a/kvirt/k3s/kcli_default.yml
+++ b/kvirt/k3s/kcli_default.yml
@@ -1,48 +1,51 @@
 info: |
-    Deploys the k3s kubernetes distrobution using an arbitrary number of masters and workers.
+    Deploys the K3s kubernetes distrobution using an arbitrary number of masters and workers.
     Specific components can be disabled by using the array disabled_components.
     install_k3s_channel defaults to stable, although latest or testing can also be selected.
     With install_k3s_version you can specify a specific version relative to the install/release
     k3s channel. Defaults to latest.
-masters: 1
-workers: 0
-sdn: flannel
+    With k3s_extra_args_all & k3s_extra_args_workers you can define all the options available for customizing
+    the install of K3s. E.g. --disable, --tls-san and so forth.
 api_ip:
-install_k3s_channel: stable
-install_k3s_version: latest
-pool: default
-image: ubuntu2004
-network: default
 cluster: testk
-domain: karmalabs.com
-token: supersecret
-numcpus: 2
-worker_numcpus:
-master_numcpus:
-memory: 1024
-master_memory:
-worker_memory:
-master_tpm: false
-master_rng: false
-disk_size: 10
-worker_tpm: false
-worker_rng: false
-notifycmd: "kubectl get pod -A"
-notify: false
-numa:
-numa_master:
-numa_worker:
-numamode:
-numamode_master:
-numamode_worker:
 cpupinning:
 cpupinning_master:
 cpupinning_worker:
-kubevirt_disk_size:
+disk_size: 10
 extra_disks: []
 extra_master_disks: []
 extra_worker_disks: []
 extra_networks: []
 extra_master_networks: []
 extra_worker_networks: []
-disabled_components: []
+domain: karmalabs.com
+image: ubuntu2004
+install_k3s_channel: stable
+install_k3s_version: latest
+k3s_extra_args_all: []
+k3s_extra_args_masters: []
+k3s_extra_args_workers: []
+kubevirt_disk_size:
+master_memory:
+master_numcpus:
+master_rng: false
+master_tpm: false
+masters: 1
+memory: 1024
+network: default
+notify: false
+notifycmd: "kubectl get pod -A"
+numa:
+numa_master:
+numa_worker:
+numamode:
+numamode_master:
+numamode_worker:
+numcpus: 2
+pool: default
+token: supersecret
+worker_memory:
+worker_numcpus:
+worker_rng: false
+worker_tpm: false
+workers: 0

--- a/kvirt/k3s/masters.sh
+++ b/kvirt/k3s/masters.sh
@@ -1,10 +1,10 @@
 {% set extra_args = [] %}
-{% for component in disabled_components %}
-{% do extra_args.append("--disable " + component) %}
+{% for component in k3s_extra_args_all %}
+{% do extra_args.append(component) %}
+{% endfor %}
+{% for component in k3s_extra_args_masters %}
+{% do extra_args.append(component) %}
 {% endfor %}
 apt-get -y install curl
-{% if sdn == 'cilium' %}
-echo bpffs /sys/fs/bpf bpf defaults 0 0 >> /etc/fstab
-mount /sys/fs/bpf
-{% endif %}
-curl -sfL https://get.k3s.io | {{ "INSTALL_K3S_EXEC='--disable-network-policy --no-flannel'" if sdn != "flannel" else '' }} INSTALL_K3S_CHANNEL={{ install_k3s_channel }} INSTALL_K3S_VERSION={{ install_k3s_version if install_k3s_version != "latest" else '' }} K3S_TOKEN={{ token }} K3S_URL=https://{{ api_ip }}:6443 sh -s - server {{ extra_args|join(" ") }}
+curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL={{ install_k3s_channel }} INSTALL_K3S_VERSION={{ install_k3s_version if install_k3s_version != "latest" else '' }} K3S_TOKEN={{ token }} K3S_URL=https://{{ api_ip }}:6443 sh -s - server {{ extra_args|join(" ") }}
+apt-get -y remove curl

--- a/kvirt/k3s/workers.yml
+++ b/kvirt/k3s/workers.yml
@@ -20,15 +20,8 @@
  pool: {{ pool }}
  numcpus: {{ worker_numcpus | default(numcpus, numcpus) }}
  memory: {{ worker_memory | default(memory, memory) }}
- files:
-  - path: /root/join.sh
-    origin: {{ basedir }}/clusters/{{ cluster }}/join.sh
- cmds:
- - apt-get -y install curl
-{% if sdn == 'cilium' %}
- - mount bpffs -t bpf /sys/fs/bpf
-{% endif %}
- - bash /root/join.sh
+ scripts:
+  - join.sh
 {% if numa != None %}
  numa: {{ numa }}
 {% endif %}


### PR DESCRIPTION
So that an KCLI end-user can specify
K3s configuration & installation args as wanted. Not only --disabled

.gitignore:
- small brush-up
- add kubectl to be ignored. Useful when developing locally

config.py:
- conditional on the k3s worker join.sh script. In order to support both cmds in vmrules in a k3s deploy plan file
- small brush-ups
- the ability to send in the name of the cluster, to reach join.sh

__init__.py k3s:
- supports specifying the version for workers
- only generate the join.sh file if any workers are to be installed
- k3s install & config args for workers
- remove cURL as it's not an requirement for K3s & is a security liability

bootstrap.sh:
- remove cURL, see reason above
- support all k3s conf. & install args

kcli_default:
- alphabetic order of params
- extra info
- added k3s args parameters
-- k3s_extra_args_all
-- k3s_extra_args_masters
-- k3s_extra_args_workers

masters.sh:
- support all k3s install & conf. args
- remove cURL, see reason above

workers.yml:
- use the scripts clause approach in order to support cmds in a k3s plan

This feature also:
- removes the sdn parameter
 KCLI users can specify to remove
 the default CNI == flannel with k3s install
 & conf. args & then after the fact install
 the CNI they want