### PR TITLE
typecast size as a string in order to avoid `int is not iterable` err

### DIFF
--- a/kvirt/providers/kubevirt/__init__.py
+++ b/kvirt/providers/kubevirt/__init__.py
@@ -733,7 +733,7 @@ class Kubevirt(Kubecommon):
                     error("pvc %s not found. That can't be good" % pvcname)
                     pvc = 'N/A'
                     size = "0"
-                if 'Mi' in size:
+                if 'Mi' in str(size):
                     size = int(size.replace('Mi', '')) / 1024
                 else:
                     size = int(size)


### PR DESCRIPTION
Full err:

```text
Traceback (most recent call last):
  File "/Users/lars/.kcli/dev/bin/kcli", line 33, in <module>
    sys.exit(load_entry_point('kcli', 'console_scripts', 'kcli')())
  File "/Users/lars/.kcli/dev/src/kcli/kvirt/cli.py", line 3868, in cli
    args.func(args)
  File "/Users/lars/.kcli/dev/src/kcli/kvirt/cli.py", line 1430, in create_k3s_kube
    config.create_kube_k3s(cluster, overrides=overrides)
  File "/Users/lars/.kcli/dev/src/kcli/kvirt/config.py", line 2201, in create_kube_k3s
    k3s.create(self, plandir, cluster, overrides)
  File "/Users/lars/.kcli/dev/src/kcli/kvirt/k3s/__init__.py", line 99, in create
    result = config.plan(plan, inputfile='%s/bootstrap.yml' % plandir, overrides=data)
  File "/Users/lars/.kcli/dev/src/kcli/kvirt/config.py", line 1791, in plan
    self.wait(name)
  File "/Users/lars/.kcli/dev/src/kcli/kvirt/config.py", line 2134, in wait
    image = k.info(name)['image']
  File "/Users/lars/.kcli/dev/src/kcli/kvirt/providers/kubevirt/__init__.py", line 736, in info
    if 'Mi' in size:
```

We found the fix on my local box when you gave me support some days ago. The fix just never came in. So here goes