### PR TITLE
build: add GHA for issue labeling, stale prs and issues, tag pointer …

### DIFF
--- a/.github/workflows/.github/dependabot.yml
+++ b/.github/workflows/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+        prefix: build
+        prefix-development: chore
+        include: scope

--- a/.github/workflows/.github/labels.yml
+++ b/.github/workflows/.github/labels.yml
@@ -1,0 +1,16 @@
+# Add 'repo' label to any root file changes
+kcli:
+  - ./*
+
+documentation:
+  - docs/**/*
+
+actions:
+  - .github/**/*
+
+extras:
+  - extras/**/*
+
+
+kcli:
+  - kvirt/**/*

--- a/.github/workflows/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/.github/workflows/broken-link-check.yml
@@ -1,0 +1,18 @@
+on:
+  schedule:
+    - cron: "0 0 * * *" # daily
+  repository_dispatch: # run manually
+    types: [check-link]
+  # push:
+  # ...
+
+name: Broken Link Check
+jobs:
+  check:
+    name: Broken Link Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Broken Link Check
+        uses: technote-space/broken-link-checker-action@v2.2.5
+        with:
+          EXCLUDED_KEYWORDS: "*.md, camo.githubusercontent.com"

--- a/.github/workflows/.github/workflows/greetings.yml
+++ b/.github/workflows/.github/workflows/greetings.yml
@@ -1,0 +1,13 @@
+name: Greetings
+
+on: [pull_request_target, issues]
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/first-interaction@v1.1.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-message: 'Thank you for raising this issue'
+        pr-message: 'Thank you for making this first PR'

--- a/.github/workflows/.github/workflows/label.yml
+++ b/.github/workflows/.github/workflows/label.yml
@@ -1,0 +1,13 @@
+name: "Label PRs from globs"
+on:
+  schedule:
+  - cron: "0 * * * *"
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: jpmcb/prow-github-actions@v1.1.2
+      with:
+        jobs: 'pr-labeler'
+        github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/.github/workflows/release.yml
+++ b/.github/workflows/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+
+      - uses: actions/setup-python@v2.2.2
+      - uses: actions/cache@v2.1.5
+        with:
+          path: |
+            ~/.cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('**/.pre-commit-config.yaml/*') }}
+          restore-keys: |
+            ${{ runner.os }}-precommit-
+
+      - uses: actions/cache@v2.1.5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f test-requirements.txt ]; then pip install -r test-requirements.txt; fi
+
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v2
+        id: semantic
+        with:
+          extra_plugins: |
+            @semantic-release/git
+            @semantic-release/changelog
+            @semantic-release/commit-analyzer
+            @semantic-release/release-notes-generator
+            @semantic-release/exec
+            @semantic-release/git
+            @semantic-release/github
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHA }}

--- a/.github/workflows/.github/workflows/stale.yml
+++ b/.github/workflows/.github/workflows/stale.yml
@@ -1,0 +1,20 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3.0.19
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days'
+        days-before-stale: 60
+        days-before-close: 7
+        stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days'
+        stale-issue-label: 'no-issue-activity'
+        exempt-issue-labels: 'awaiting-approval,work-in-progress'
+        stale-pr-label: 'no-pr-activity'
+        exempt-pr-labels: 'awaiting-approval,work-in-progress'

--- a/.github/workflows/.github/workflows/update_semver.yml
+++ b/.github/workflows/.github/workflows/update_semver.yml
@@ -1,0 +1,17 @@
+name: Update Semver
+on:
+  push:
+    tags:
+      - '*.*.*'
+  release:
+     types:
+       - published
+
+jobs:
+  update-semver:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: haya14busa/action-update-semver@v1.2.1
+        with:
+          major_version_tag_only: false  # (optional, default is "false")

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ prout.yml
 .cache/
 kvirt/static/reports/*
 venv*
+.history/

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,23 @@
+{
+  "branch": "master",
+  "repositoryUrl": "git@github.com:karmab/kcli.git",
+  "tagFormat": "${version}",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "./CHANGELOG.md"
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "pre-commit run --files CHANGELOG.md; pre-commit  run --files CHANGELOG.md"
+      }
+    ],
+    "@semantic-release/git",
+    "@semantic-release/github"
+  ]
+}

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,11 @@
+coverage!=4.4,>=4.0 # Apache-2.0
+flake8
+misspellings
+pre-commit
+pymarkdownlint
+pytest>=3.2.0 # MIT
+pytest-cov>=2.5.1 # MIT
+PyYAML
+requests
+setuptools>=30
+tox


### PR DESCRIPTION
Adds GHA configuration for:

- labelling of pr's
- greeting new contributors
- mark stale pr's / issues
- check broken links
- dependabot configuration for updating gha's and dependencies
- update tag pointers so that patch, minor, release get updated when a new release happens
- autorelease based on commitizen-style of commits

Closes #218 