### PR TITLE
Fix to make the joincmd work

### DIFF
--- a/kvirt/k3s/__init__.py
+++ b/kvirt/k3s/__init__.py
@@ -123,7 +123,7 @@ def create(config, plandir, cluster, overrides):
                                                                                               api_ip, token)
         extra_args = data['extra_worker_args'] if data.get('extra_worker_args', []) else data.get('extra_args', [])
         extra_args = ' '.join(extra_args)
-        f.write("%s sh - %s \n" % (joincmd, extra_args))
+        f.write("%s sh -s - agent %s \n" % (joincmd, extra_args))
     source, destination = "/root/kubeconfig", "%s/auth/kubeconfig" % clusterdir
     scpcmd = scp(firstmaster, ip=firstmasterip, user='root', source=source, destination=destination,
                  tunnel=config.tunnel, tunnelhost=config.tunnelhost, tunnelport=config.tunnelport,


### PR DESCRIPTION
- The joincmd for a dK3s installation on worker
nodes was not working when K3s installation
args where included.
One would get an err. a la = Cannot open K3s_ARG.
This fixes that.
- Adding just sh -s is enough but I have added
agent as well, to make it straightforward to see
that the args are to the k3s executable