### PR TITLE
Fix bucket creation via cli

### DIFF
--- a/kvirt/cli.py
+++ b/kvirt/cli.py
@@ -2703,8 +2703,9 @@ def create_bucket(args):
     public = args.public
     config = Kconfig(client=args.client, debug=args.debug, region=args.region, zone=args.zone, namespace=args.namespace)
     k = config.k
-    pprint("Creating bucket %s..." % bucket)
-    k.create_bucket(bucket, public=public)
+    for b in bucket:
+        pprint("Creating bucket %s..." % b)
+        k.create_bucket(b, public=public)
 
 
 def delete_bucket(args):


### PR DESCRIPTION
Buckets via CLI are a list type arg, therefore they should be iterated before using the providers functions.