### PR TITLE
Brushups on K3s worker/agents. Network related K3s binary args

### DIFF
--- a/kvirt/k3s/__init__.py
+++ b/kvirt/k3s/__init__.py
@@ -111,7 +111,7 @@ def create(config, plandir, cluster, overrides):
     nodes_overrides = data.copy()
     nodes_install_k3s_args = install_k3s_args.copy()
     if sdn is None or sdn != 'flannel':
-        nodes_install_k3s_args.append("INSTALL_K3S_EXEC='--disable-network-policy --no-flannel'")
+        nodes_install_k3s_args.append("INSTALL_K3S_EXEC='--disable-network-policy --flannel-backend=none'")
     nodes_install_k3s_args = ' '.join(nodes_install_k3s_args)
     nodes_overrides['install_k3s_args'] = nodes_install_k3s_args
     if masters > 1:

--- a/kvirt/k3s/__init__.py
+++ b/kvirt/k3s/__init__.py
@@ -111,7 +111,7 @@ def create(config, plandir, cluster, overrides):
     nodes_overrides = data.copy()
     nodes_install_k3s_args = install_k3s_args.copy()
     if sdn is None or sdn != 'flannel':
-        nodes_install_k3s_args.append("INSTALL_K3S_EXEC='--disable-network-policy --flannel-backend=none'")
+        nodes_install_k3s_args.append("INSTALL_K3S_EXEC='--flannel-backend=none'")
     nodes_install_k3s_args = ' '.join(nodes_install_k3s_args)
     nodes_overrides['install_k3s_args'] = nodes_install_k3s_args
     if masters > 1:

--- a/kvirt/k3s/__init__.py
+++ b/kvirt/k3s/__init__.py
@@ -121,8 +121,7 @@ def create(config, plandir, cluster, overrides):
     with open("%s/join.sh" % clusterdir, 'w') as f:
         if api_ip is None:
             api_ip = k.info(firstmaster)['ip']
-        joincmd = "curl -sfL https://get.k3s.io | %s K3S_URL=https://%s:6443 K3S_TOKEN=%s" % (nodes_install_k3s_args,
-                                                                                              api_ip, token)
+        joincmd = "curl -sfL https://get.k3s.io | K3S_URL=https://%s:6443 K3S_TOKEN=%s" % (api_ip, token)
         extra_args = data['extra_worker_args'] if data.get('extra_worker_args', []) else data.get('extra_args', [])
         extra_args = ' '.join(extra_args)
         f.write("%s sh -s - agent %s \n" % (joincmd, extra_args))


### PR DESCRIPTION
Just as we do on the bootstrapping part in the create() func. also use `--flannel-backend=none` for the worker setup in the create() func.