### PR TITLE
Fix issue of extra masters mistaken as K3s agents

### DIFF
--- a/kvirt/k3s/masters.sh
+++ b/kvirt/k3s/masters.sh
@@ -7,5 +7,5 @@ apt-get -y install curl
 echo bpffs /sys/fs/bpf bpf defaults 0 0 >> /etc/fstab
 mount /sys/fs/bpf
 {% endif %}
-curl -sfL https://get.k3s.io | {{ install_k3s_args }} K3S_TOKEN={{ token }} K3S_URL=https://{{ api_ip }}:6443 sh -s - server {{ extra_args|join(" ") }}
+curl -sfL https://get.k3s.io | {{ install_k3s_args }} K3S_TOKEN={{ token }} sh -s - server --server https://{{ api_ip }}:6443 {{ extra_args|join(" ") }}
 apt-get -y remove curl


### PR DESCRIPTION
The fix is to go away from the use of the K3S_URL. Specifying that apparently makes the K3s binary interpret the install cmd as being for a K3s agent/worker node. Whereas using `--serer https://serverIP:6443` makes the K3s binary properly interpret the install cmd as being for a K3s master/control-plane node.

Tested on local and works for both a CNI that is not flannel and when specifying `sdn: flannel`

Give me a merge 😉 🍻