### PR TITLE
providers/kvm: fix info host output

### DIFF
--- a/kvirt/providers/kvm/__init__.py
+++ b/kvirt/providers/kvm/__init__.py
@@ -1334,10 +1334,20 @@ class Kvirt(object):
             available = float(available)
             print(("Storage:%s Type: %s Path:%s Used space: %sGB Available space: %sGB" % (poolname, pooltype, poolpath,
                                                                                            used, available)))
-        for interface in conn.listInterfaces():
-            if interface == 'lo':
-                continue
-            print("Network: %s Type: bridged" % interface)
+        try:
+            for interface in conn.listInterfaces():
+                if interface == 'lo':
+                    continue
+                print("Network: %s Type: bridged" % interface)
+        except libvirtError as e:
+            # at some host it is not possible to list interfaces because of permissions
+            # (for example using qemu:///session instead of qemu:///system), or because
+            # of bugs (like in openSUSE Leap 15.3 and earlier).
+            if 'this function is not supported by the connection driver: virConnectNumOfInterfaces' in str(e):
+                print("Network: system interfaces are unavailable")
+            else:
+                raise(e)
+
         for network in conn.listAllNetworks():
             networkname = network.name()
             netxml = network.XMLDesc(0)


### PR DESCRIPTION
When runing 'kcli info host' against openSUSE Leap 15.3 and earlier
and some other host specific configuration it is impossible to
call libvirt.virConnect.listInterfaces without an error:

      Traceback (most recent call last):
        File "/Users/kyr/kshtsk/kcli/v/bin/kcli", line 33, in <module>
          sys.exit(load_entry_point('kcli', 'console_scripts', 'kcli')())
        File "/Users/kyr/kshtsk/kcli/kvirt/cli.py", line 4323, in cli
          args.func(args)
        File "/Users/kyr/kshtsk/kcli/kvirt/cli.py", line 2855, in report_host
          k.report()
        File "/Users/kyr/kshtsk/kcli/kvirt/providers/kvm/__init__.py", line 1337, in report
          for interface in conn.listInterfaces():
        File "/Users/kyr/kshtsk/kcli/v/lib/python3.9/site-packages/libvirt.py", line 4815, in listInterfaces
          raise libvirtError('virConnectListInterfaces() failed')
      libvirt.libvirtError: this function is not supported by the connection driver: virConnectNumOfInterfaces

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@gmail.com>