### PR TITLE
Added parameter to override remote-viewer command for consoles

### DIFF
--- a/kvirt/cli.py
+++ b/kvirt/cli.py
@@ -229,10 +229,11 @@ def console_vm(args):
     name = common.get_lastvm(config.client) if not args.name else args.name
     k = config.k
     tunnel = config.tunnel
+    consolecmd = config.consolecmd
     if serial:
         k.serialconsole(name)
     else:
-        k.console(name=name, tunnel=tunnel)
+        k.console(name=name, tunnel=tunnel, consolecmd=consolecmd)
 
 
 def console_container(args):
@@ -1177,7 +1178,7 @@ def create_vm(args):
                                   onlyassets=onlyassets)
         if not onlyassets:
             if console:
-                config.k.console(name=name, tunnel=config.tunnel)
+                config.k.console(name=name, tunnel=config.tunnel, consolecmd=config.consolecmd)
             elif serial:
                 config.k.serialconsole(name)
             else:

--- a/kvirt/defaults.py
+++ b/kvirt/defaults.py
@@ -205,3 +205,4 @@ VMRULES = []
 CACHE = False
 SECURITYGROUPS = []
 LOCAL_OPENSHIFT_APPS = ['argocd', 'istio', 'users']
+CONSOLECMD = "remote-viewer"

--- a/kvirt/krpc/cli.py
+++ b/kvirt/krpc/cli.py
@@ -210,7 +210,7 @@ def console_vm(args):
         os.system(cmd)
     else:
         cmd = k.console(kcli_pb2.vm(name=name)).cmd
-        os.popen("remote-viewer %s &" % cmd)
+        os.popen("%s %s &" % (config.consolecmd, cmd)
 
 
 def console_container(args):

--- a/kvirt/providers/kubevirt/__init__.py
+++ b/kvirt/providers/kubevirt/__init__.py
@@ -530,7 +530,7 @@ class Kubevirt(Kubecommon):
             vms.append(self.info(name, vm=vm))
         return sorted(vms, key=lambda x: x['name'])
 
-    def console(self, name, tunnel=False, web=False):
+    def console(self, name, tunnel=False, web=False, consolecmd='remote-viewer'):
         if os.path.exists("/i_am_a_container"):
             error("This functionality is not supported in container mode")
             return
@@ -559,7 +559,7 @@ class Kubevirt(Kubecommon):
         time.sleep(5)
         if web:
             return "vnc://127.0.0.1:%s" % localport
-        consolecommand = "remote-viewer vnc://127.0.0.1:%s &" % localport
+        consolecommand = "%s vnc://127.0.0.1:%s &" % (consolecmd, localport)
         if self.debug:
             msg = "Run the following command:\n%s" % consolecommand if not self.debug else consolecommand
             pprint(msg)

--- a/kvirt/providers/kvm/__init__.py
+++ b/kvirt/providers/kvm/__init__.py
@@ -1378,7 +1378,7 @@ class Kvirt(object):
             vms.append(self.info(vm.name(), vm=vm))
         return sorted(vms, key=lambda x: x['name'])
 
-    def console(self, name, tunnel=False, web=False):
+    def console(self, name, tunnel=False, web=False, consolecmd='remote-viewer'):
         conn = self.conn
         try:
             vm = conn.lookupByName(name)
@@ -1414,10 +1414,7 @@ class Kvirt(object):
                     if tunnel:
                         os.popen(consolecommand)
                     return url
-                if os.path.exists('/Applications') and os.path.exists('/Applications/RemoteViewer'):
-                    consolecommand += "open -a RemoteViewer —args %s &" % url
-                else:
-                    consolecommand += "remote-viewer %s &" % url
+                consolecommand += "%s %s &" % (consolecmd, url)
                 if self.debug or os.path.exists("/i_am_a_container"):
                     msg = "Run the following command:\n%s" % consolecommand if not self.debug else consolecommand
                     pprint(msg)

--- a/kvirt/providers/ovirt/__init__.py
+++ b/kvirt/providers/ovirt/__init__.py
@@ -425,7 +425,7 @@ class KOvirt(object):
             vms.append(self.info(vm.name, vm=vm))
         return sorted(vms, key=lambda x: x['name'])
 
-    def console(self, name, tunnel=False, web=False):
+    def console(self, name, tunnel=False, web=False, consolecmd='remote-viewer'):
         connectiondetails = None
         vmsearch = self.vms_service.list(search='name=%s' % name)
         if not vmsearch:
@@ -506,10 +506,10 @@ release-cursor=shift+f12""".format(address=address, port=port, ticket=ticket.val
         with open("/tmp/console.vv", "w") as f:
             f.write(connectiondetails)
         if self.debug or os.path.exists("/i_am_a_container"):
-            msg = "Use remote-viewer with this:\n%s" % connectiondetails if not self.debug else connectiondetails
+            msg = "Use %s with this:\n%s" % (consolecmd, connectiondetails if not self.debug else connectiondetails)
             pprint(msg)
         else:
-            os.popen("remote-viewer /tmp/console.vv &")
+            os.popen("%s /tmp/console.vv &" % consolecmd)
         return
 
     def serialconsole(self, name, web=False):

--- a/kvirt/providers/vsphere/__init__.py
+++ b/kvirt/providers/vsphere/__init__.py
@@ -767,7 +767,7 @@ class Ksphere:
                 planfolder.Destroy()
         return {'result': 'success'}
 
-    def console(self, name, tunnel=False, web=False):
+    def console(self, name, tunnel=False, web=False, consolecmd='remote-viewer'):
         si = self.si
         dc = self.dc
         vcip = self.vcip
@@ -792,7 +792,7 @@ class Ksphere:
         if vncfound:
             host = vm.runtime.host.name
             url = "vnc://%s:%s" % (host, vncport)
-            consolecommand = "remote-viewer %s &" % (url)
+            consolecommand = "%s %s &" % (consolecmd, url)
             if web:
                 return url
             if self.debug or os.path.exists("/i_am_a_container"):


### PR DESCRIPTION
Useful if remote-viewer is not available in the installed platform or if the viewer differs between hypervisors or if the user just wants to use a different viewer for his/her own reasons.