### PR TITLE
samples/config.yml:  Correct array definitions

### DIFF
--- a/samples/config.yml
+++ b/samples/config.yml
@@ -68,9 +68,9 @@ default:
  # Array of ssh public keys to inject to the vm
  keys:
  # Array of commands to run through cloudinit
- cmds:
+ cmds: []
  # array of paths of custom script to inject with cloudinit. It will be merged with cmds parameter. You can either specify full paths or relative to where you're running kcli. Only checked in profile or plan file
- scripts:
+ scripts: []
  # name of one of your profiles. Only checked in plan file
  profile:
  # Nested virtualization


### PR DESCRIPTION
Arrays weren't defined as such leading to failures:

 ```
 File "/usr/lib/python3.6/site-packages/kvirt/config.py", line 692, in create_vm                                                                                 
    cmds = common.remove_duplicates(default_cmds + profile.get('cmds', []))
```