### PR TITLE
cmdline, rhcos: Run virt-edit with sudo.

### DIFF
--- a/kvirt/providers/kvm/__init__.py
+++ b/kvirt/providers/kvm/__init__.py
@@ -1192,7 +1192,7 @@ class Kvirt(object):
         if firstdisk is not None and ('rhcos' in image or 'fcos' in image) and cmdline is not None:
             bootdisk = '/dev/sda3'
             bootfile = "/boot/loader/entries/ostree-1-rhcos.conf"
-            cmd = "virt-edit -a %s -m %s %s -e 's/^options/options %s/'" % (firstdisk, bootdisk, bootfile, cmdline)
+            cmd = "sudo virt-edit -a %s -m %s %s -e 's/^options/options %s/'" % (firstdisk, bootdisk, bootfile, cmdline)
             if self.host == 'localhost' or self.host == '127.0.0.1':
                 if find_executable('virt-edit') is not None:
                     os.system(cmd)


### PR DESCRIPTION
To run virt-edit is not enough for the user to be at "libvirt" group.
This change run the virt-edit to manipulate cmdline using sudo so users
don't have to run all the kcli with sudo.

Signed-off-by: Quique Llorente <ellorent@redhat.com>