### PR TITLE
Update masters.sh

### DIFF
--- a/kvirt/k3s/masters.sh
+++ b/kvirt/k3s/masters.sh
@@ -8,4 +8,3 @@ echo bpffs /sys/fs/bpf bpf defaults 0 0 >> /etc/fstab
 mount /sys/fs/bpf
 {% endif %}
 curl -sfL https://get.k3s.io | {{ install_k3s_args }} K3S_TOKEN={{ token }} sh -s - server --server https://{{ api_ip }}:6443 {{ extra_args|join(" ") }}
-apt-get -y remove curl


### PR DESCRIPTION
Do not remove`cURL` as it is used inside the keepalived check script - https://github.com/karmab/kcli/blob/0453417a8296f16a1dc9143841e9e64456bc1471/kvirt/k3s/keepalived.conf#L2 ... so for now we need to **NOT** uninstall `cURL` .... if we think it's a security liability to have ´cURL` on a node then we have to revisit this later on. E.g. maybe `nc` can be  used instead. I think that's always on a Linux distro per default.