### PR TITLE
Do not remove cURL for K3s installs

### DIFF
--- a/kvirt/k3s/bootstrap.sh
+++ b/kvirt/k3s/bootstrap.sh
@@ -19,4 +19,3 @@ tar xzvfC cilium-linux-amd64.tar.gz /usr/local/bin
 rm -f cilium-linux-amd64.tar.gz
 cilium install
 {% endif %}
-apt-get -y remove curl

--- a/kvirt/k3s/masters.sh
+++ b/kvirt/k3s/masters.sh
@@ -8,4 +8,3 @@ echo bpffs /sys/fs/bpf bpf defaults 0 0 >> /etc/fstab
 mount /sys/fs/bpf
 {% endif %}
 curl -sfL https://get.k3s.io | {{ install_k3s_args }} K3S_TOKEN={{ token }} sh -s - server --server https://{{ api_ip }}:6443 {{ extra_args|join(" ") }}
-apt-get -y remove curl

--- a/kvirt/k3s/workers.yml
+++ b/kvirt/k3s/workers.yml
@@ -23,5 +23,4 @@
  - mount bpffs -t bpf /sys/fs/bpf
 {% endif %}
  - bash /root/join.sh
- - apt-get -y remove curl
 {% endfor %}


### PR DESCRIPTION
As cURL is needed for the keepalived script