### PR TITLE
Add missing python3-bcrypt dependency

### DIFF
--- a/.github/prep.sh
+++ b/.github/prep.sh
@@ -1,5 +1,5 @@
 apt-get update
-apt-get -y install python3-pip python3-wheel python3-setuptools python3-all python3-distutils dh-python debhelper build-essential fakeroot 
+apt-get -y install python3-pip python3-wheel python3-setuptools python3-all python3-distutils dh-python debhelper build-essential fakeroot python3-bcrypt
 pip3 install misspellings cloudsmith-cli pep8 stdeb
 pip3 install -U Jinja2
 apt-get -y install libvirt-daemon libvirt0 qemu-system-x86 qemu-utils qemu-kvm libvirt-daemon-system curl genisoimage python3-libvirt

--- a/kcli.spec
+++ b/kcli.spec
@@ -16,7 +16,7 @@ Source:         {{{ git_dir_pack }}}
 AutoReq:        no
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  python3-devel rubygem-ronn gzip python3-setuptools
-Requires:       python3 libvirt-python3 genisoimage nmap-ncat python3-prettytable python3-PyYAML python3-flask python3-argcomplete python3-requests
+Requires:       python3 libvirt-python3 genisoimage nmap-ncat python3-prettytable python3-PyYAML python3-flask python3-argcomplete python3-requests python3-bcrypt
 
 %description
 Kcli is meant to interact with a local/remote libvirt, gcp, aws ovirt,


### PR DESCRIPTION
On a fresh F35 install `kcli` fails with the following traceback:
```
$ kcli list vms
Traceback (most recent call last):
  File "/usr/bin/kcli", line 33, in <module>
    sys.exit(load_entry_point('kcli==99.0', 'console_scripts', 'kcli')())
  File "/usr/bin/kcli", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "/usr/lib64/python3.10/importlib/metadata/__init__.py", line 162, in load
    module = import_module(match.group('module'))
  File "/usr/lib64/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/usr/lib/python3.10/site-packages/kvirt/cli.py", line 8, in <module>
    from kvirt.config import Kconfig
  File "/usr/lib/python3.10/site-packages/kvirt/config.py", line 25, in <module>
    from kvirt import openshift
  File "/usr/lib/python3.10/site-packages/kvirt/openshift/__init__.py", line 4, in <module>
    import bcrypt
ModuleNotFoundError: No module named 'bcrypt'
```
This PR explicitly adds this dependency to the spec file.