### PR TITLE
Fix kata containers install on generic Kube cluster

### DIFF
--- a/kvirt/kubeadm/apps/katacontainer/install.sh
+++ b/kvirt/kubeadm/apps/katacontainer/install.sh
@@ -1,2 +1,11 @@
-curl https://raw.githubusercontent.com/openshift/kata-operator/release-{{ openshift_version }}/deploy/deploy-k8s.sh | bash
-oc apply -f https://raw.githubusercontent.com/openshift/kata-operator/release-{{ openshift_version }}/deploy/crds/kataconfiguration.openshift.io_v1alpha1_kataconfig_cr_k8s.yaml
+kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/kata-rbac/base/kata-rbac.yaml
+
+{% if katacontainer_version != 'stable' %}
+kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+{% else %}
+kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy-stable.yaml
+{% endif %}
+
+kubectl -n kube-system wait --timeout=10m --for=condition=Ready -l name=kata-deploy pod
+
+kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml

--- a/kvirt/kubeadm/apps/katacontainer/uninstall.sh
+++ b/kvirt/kubeadm/apps/katacontainer/uninstall.sh
@@ -1,1 +1,11 @@
-oc delete -f https://raw.githubusercontent.com/openshift/kata-operator/release-{{ openshift_version }}/deploy/crds/kataconfiguration.openshift.io_v1alpha1_kataconfig_cr.yaml
+{% if katacontainer_version != 'stable' %}
+kubectl delete -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+{% else %}
+kubectl delete -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy-stable.yaml
+{% endif %}
+
+kubectl -n kube-system wait --timeout=10m --for=delete -l name=kata-deploy pod
+
+kubectl delete -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
+kubectl delete -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/kata-rbac/base/kata-rbac.yaml
+kubectl delete -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml


### PR DESCRIPTION
The install/uninstall script uses the official kata-deploy manifests from the Kata repository