### PR TITLE
Fix the addition of pubkeys with no keys provided

### DIFF
--- a/kvirt/common/__init__.py
+++ b/kvirt/common/__init__.py
@@ -307,7 +307,7 @@ def cloudinit(name, keys=[], cmds=[], nets=[], gateway=None, dns=None, domain=No
         if publickeyfile is not None:
             with open(publickeyfile, 'r') as ssh:
                 key = ssh.read().rstrip()
-                if key not in keys:
+                if keys is None or key not in keys:
                     userdata += "- %s\n" % key
         tempkeydir = overrides.get('tempkeydir')
         if tempkeydir is not None:


### PR DESCRIPTION
In the last commit a bug was introduced when no `keys` were provided as
parameter. In that case, `keys` would have been `None` and the comparison
`if key not in keys` would fail:

~~~
  File "/usr/lib/python3.10/site-packages/kvirt/common/__init__.py", line 312, in cloudinit
    if key not in keys:
TypeError: argument of type 'NoneType' is not iterable
~~~

Fixes: 6d7dadcbbd1f ("dont put pub keys twice in cloudinit")