### PR TITLE
kubeadm: source env variables in pre_*.sh, keepalived.sh, and apache.sh

### DIFF
--- a/kvirt/kubeadm/apache.sh
+++ b/kvirt/kubeadm/apache.sh
@@ -1,3 +1,6 @@
+# source env variables, if present
+test -f /etc/profile.d/kcli.sh && source /etc/profile.d/kcli.sh
+
 PKGMGR="{{ 'apt-get' if ubuntu else 'yum' }}"
 PKGS="{{ 'apache2 apache2-utils' if ubuntu else 'httpd httpd-tools' }}"
 SERVICE="{{ 'apache2' if ubuntu else 'httpd' }}"

--- a/kvirt/kubeadm/keepalived.sh
+++ b/kvirt/kubeadm/keepalived.sh
@@ -1,3 +1,6 @@
+# source env variables, if present
+test -f /etc/profile.d/kcli.sh && source /etc/profile.d/kcli.sh
+
 PKGMGR="{{ 'apt-get' if ubuntu else 'yum' }}"
 $PKGMGR -y install keepalived
 NETMASK=$(ip -o -f inet addr show | awk '/scope global/ {print $4}' | head -1 | cut -d'/' -f2)

--- a/kvirt/kubeadm/pre_el.sh
+++ b/kvirt/kubeadm/pre_el.sh
@@ -1,3 +1,6 @@
+# source env variables, if present
+test -f /etc/profile.d/kcli.sh && source /etc/profile.d/kcli.sh
+
 echo """[kubernetes]
 name=Kubernetes
 baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64

--- a/kvirt/kubeadm/pre_ubuntu.sh
+++ b/kvirt/kubeadm/pre_ubuntu.sh
@@ -1,3 +1,6 @@
+# source env variables, if present
+test -f /etc/profile.d/kcli.sh && source /etc/profile.d/kcli.sh
+
 apt-get update && apt-get -y install apt-transport-https curl git
 curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 cat <<EOF >/etc/apt/sources.list.d/kubernetes.list


### PR DESCRIPTION
Just changing 'master.sh' seems not enough. Other scripts that use 'apt' or 'dnf' also need to source variables to be in proxy settings.
After fixing these files, I can reach until "kubeadm init" starts even when using proxy settings.
Signed-off-by: Hyeongju Johannes Lee <hyeongju.lee@intel.com>