### PR TITLE
kvm: Change default keys value to an empty list

### DIFF
--- a/kvirt/providers/kvm/__init__.py
+++ b/kvirt/providers/kvm/__init__.py
@@ -220,7 +220,7 @@ class Kvirt(object):
     def create(self, name, virttype=None, profile='kvirt', flavor=None, plan='kvirt', cpumodel='host-model',
                cpuflags=[], cpupinning=[], numcpus=2, memory=512, guestid='guestrhel764', pool='default', image=None,
                disks=[{'size': 10}], disksize=10, diskthin=True, diskinterface='virtio', nets=['default'], iso=None,
-               vnc=False, cloudinit=True, reserveip=False, reservedns=False, reservehost=False, start=True, keys=None,
+               vnc=False, cloudinit=True, reserveip=False, reservedns=False, reservehost=False, start=True, keys=[],
                cmds=[], ips=None, netmasks=None, gateway=None, nested=True, dns=None, domain=None, tunnel=False,
                files=[], enableroot=True, overrides={}, tags=[], storemetadata=False, sharedfolders=[],
                kernel=None, initrd=None, cmdline=None, placement=[], autostart=False, cpuhotplug=False,


### PR DESCRIPTION
The rest of the code assumes that instead of a `None` value.

This comes from the code inspection derived from the discussion in https://github.com/karmab/kcli/pull/417.