### PR TITLE
Pass rootpassword from overrides

### DIFF
--- a/kvirt/config.py
+++ b/kvirt/config.py
@@ -1921,6 +1921,8 @@ class Kconfig(Kbaseconfig):
                     if vmcounter >= len(vmentries):
                         os.remove(f"{plan}.key.pub")
                         os.remove(f"{plan}.key")
+                if 'rootpassword' in overrides:
+                    profile['rootpassword'] = overrides['rootpassword']
                 currentoverrides = overrides.copy()
                 if 'image' in profile:
                     for entry in self.list_profiles():


### PR DESCRIPTION
When creating an openshift cluster directly with

% kcli create kube openshift --paramfile params.yaml

the overrides for rootpassword given in params.yaml are not applied.

This fixes it, but I'm not sure this is the right place to fix it.

Signed-off-by: Christophe de Dinechin <christophe@dinechin.org>