### PR TITLE
kubeadm: fix typo of https_proxy in pre_ubuntu.sh

### DIFF
--- a/kvirt/kubeadm/pre_ubuntu.sh
+++ b/kvirt/kubeadm/pre_ubuntu.sh
@@ -43,7 +43,7 @@ cat > /etc/systemd/system/crio.service.d/http_proxy.conf << EOF
 Environment="HTTP_PROXY={{ HTTP_PROXY }}"
 EOF
 {% if 'HTTPS_PROXY' is defined %}
-cat > /etc/systemd/system/crio.service.d/http_proxy.conf << EOF
+cat > /etc/systemd/system/crio.service.d/https_proxy.conf << EOF
 [Service]
 Environment="HTTPS_PROXY={{ HTTPS_PROXY }}"
 EOF
@@ -71,7 +71,7 @@ cat > /etc/systemd/system/containerd.service.d/http_proxy.conf << EOF
 Environment="HTTP_PROXY={{ HTTP_PROXY }}"
 EOF
 {% if 'HTTPS_PROXY' is defined %}
-cat > /etc/systemd/system/containerd.service.d/http_proxy.conf << EOF
+cat > /etc/systemd/system/containerd.service.d/https_proxy.conf << EOF
 [Service]
 Environment="HTTPS_PROXY={{ HTTPS_PROXY }}"
 EOF


### PR DESCRIPTION
Signed-off-by: Hyeongju Johannes Lee <hyeongju.lee@intel.com>