### PR TITLE
Allow kind to be exposed by ingress

### DIFF
--- a/kvirt/kind/config.yaml
+++ b/kvirt/kind/config.yaml
@@ -4,6 +4,21 @@ name: {{ cluster }}
 nodes:
 {% for master in range (0, masters) %}
 - role: control-plane
+{% if external_ingress %}
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+    listenAddress: "0.0.0.0"
+  - containerPort: 443
+    hostPort: 443
+    listenAddress: "0.0.0.0"
+{% endif %}
 {% if cni_bin_path is defined %}
   extraMounts:
   - hostPath: /root/cni_bin
@@ -11,7 +26,7 @@ nodes:
 {% endif %}
 {% endfor %}
 {% for worker in range (0, workers) %}
-- role: control-plane
+- role: worker
 {% if cni_bin_path is defined %}
   extraMounts:
   - hostPath: /root/cni_bin

--- a/kvirt/kind/kcli_plan.yml
+++ b/kvirt/kind/kcli_plan.yml
@@ -22,6 +22,9 @@
   - sed -i "s/127.0.0.1/$(hostname -i)/" /root/{{ cluster }}-config.yaml
 {% endif %}
   - kind create cluster --config /root/{{ cluster }}-config.yaml
+{% if external_ingress %}
+  - kubectl apply --kubeconfig=/.kube/config -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml 
+{% endif %}
   - mv /.kube/config {{ KUBECONFIG }}
   files:
   - path: /root/{{ cluster }}-config.yaml

--- a/kvirt/kind/kcli_plan_default.yml
+++ b/kvirt/kind/kcli_plan_default.yml
@@ -21,4 +21,5 @@ ipv6: false
 dualstack: false
 disable_default_cni: false
 external_api_address: true
+external_ingress: true
 keys: []


### PR DESCRIPTION
Since kind is deployed on a VM, I found it useful to allow it to expose services through an ingress controller (currently only nginx is deployed by default, but it can be replaced).
The behaviour can be inhibited with a kcli_parameter "external_ingress: false"