### PR TITLE
enable caching for iommu

### DIFF
--- a/kvirt/providers/kvm/__init__.py
+++ b/kvirt/providers/kvm/__init__.py
@@ -1209,7 +1209,7 @@ class Kvirt(object):
         metadataxml += "</kvirt:info></metadata>"
         iommumemxml = "<memtune><hard_limit unit='KiB'>104857600</hard_limit></memtune>" if enableiommu else ''
         iommufeaturesxml = "<acpi/><apic/><pae/><apic/><pae/><ioapic driver='qemu'/>" if enableiommu else ''
-        iommudevicexml = "<iommu model='intel'><driver intremap='on'/></iommu>" if enableiommu else ''
+        iommudevicexml = "<iommu model='intel'><driver intremap='on' caching_mode='on'/></iommu>" if enableiommu else ''
         vmxml = """<domain type='{virttype}' {namespace}>
 <name>{name}</name>
 {uuidxml}


### PR DESCRIPTION
this is needed for intel iommu to avoid qemu faulting on:
2022-09-02T11:53:42.250746Z qemu-kvm: We need to set caching-mode=on for intel-iommu to enable device assignment with IOMMU protection.
