### PR TITLE
add xz-utils to debian image

### DIFF
--- a/extras/debian
+++ b/extras/debian
@@ -16,7 +16,7 @@ RUN mkdir /root/kcli
 ADD kvirt /root/kcli/kvirt
 COPY setup.py /root/kcli
 ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
-RUN echo 'APT::Install-Recommends "0";' >> /etc/apt/apt.conf && echo 'APT::Install-Suggests "0";' >> /etc/apt/apt.conf && apt-get update && apt-get -y install gcc libvirt0 libvirt-dev genisoimage openssh-client libcurl4-openssl-dev curl libssl-dev libxml2-dev libffi-dev pkg-config && pip3 install --no-cache /root/kcli[all] && apt-get -y remove gcc libvirt-dev libcurl4-openssl-dev libssl-dev libxml2-dev libffi-dev pkg-config && apt -y autoremove && apt-get clean all
+RUN echo 'APT::Install-Recommends "0";' >> /etc/apt/apt.conf && echo 'APT::Install-Suggests "0";' >> /etc/apt/apt.conf && apt-get update && apt-get -y install gcc libvirt0 libvirt-dev genisoimage openssh-client libcurl4-openssl-dev curl libssl-dev libxml2-dev libffi-dev pkg-config xz-utils && pip3 install --no-cache /root/kcli[all] && apt-get -y remove gcc libvirt-dev libcurl4-openssl-dev libssl-dev libxml2-dev libffi-dev pkg-config && apt -y autoremove && apt-get clean all
 ADD extras/i_am_a_container /i_am_a_container
 
 RUN echo eval \"\$\(register-python-argcomplete kcli\)\" >> /root/.bashrc


### PR DESCRIPTION
```
unxz not found. Can't uncompress image
Image fcos not Added because unxznot found. Can't uncompress image
```

when downloading fcos image, which is xz compressed. [ex](
https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220906.3.2/x86_64/fedora-coreos-36.20220906.3.2-openstack.x86_64.qcow2.xz)