### PR TITLE
Random keepalived password when scaling K3s

### DIFF
--- a/kvirt/k3s/__init__.py
+++ b/kvirt/k3s/__init__.py
@@ -30,6 +30,8 @@ def scale(config, plandir, cluster, overrides):
     if os.path.exists(clusterdir):
         with open(f"{clusterdir}/kcli_parameters.yml", 'w') as paramfile:
             yaml.safe_dump(data, paramfile)
+    auth_pass = ''.join(choice(ascii_letters + digits) for i in range(5))
+    data['auth_pass'] = auth_pass
     vmrules_all_names = []
     if data.get('vmrules', config.vmrules) and data.get('vmrules_strict', config.vmrules_strict):
         vmrules_all_names = [list(entry.keys())[0] for entry in data.get('vmrules', config.vmrules)]


### PR DESCRIPTION
The scale case is currently not covered to give keepalived a random password.

I hereby suggest a code change to get it in. However, there's room for discussing the logic here. Because. Are "we" ( kcli ) really supposed to change the Keepalived password when scaling? And shouldn't it only apply to masters ... I guess it really makes no difference here as `workers` will not get `keepalived` conf. so the `auth_pass` key in `[data]`, being passed around by `kcli` will not be used ... so who cares. In other words it only really applies to masters anyways ... just also passed to workers scaled in - however not used.

----

So it's a matter of whether or not this will work in all the use-cases one can use `kcli scale` for on the control-plane/master side of a Kubernetes cluster.

_use cases_:

- scaling to introduce change where masters are interchanged ( removed ) one by one and reintroduced
- scaling the control-plane from e.g. 3 to 5 masters

----

Hmm thinking about it I think there's a probability that it'll work in the *scale-to-introduce-change* scenario. But, **NOT** in the *scale-from-3-to-5-control-plane-nodes* ....

As the masters are communicating over the `API_IP` and this IP is controlled by `keepalived` ... if the password for `keepalived` get changed on the fly ... communication won't work for the added masters - in the 3 > 5 case.

I need your thoughts here @karmab