### PR TITLE
Fix IDRAC reset URl call

### DIFF
--- a/kvirt/redfish/__init__.py
+++ b/kvirt/redfish/__init__.py
@@ -145,7 +145,8 @@ class Redfish(object):
     def reset(self):
         manager_url = self.get_manager_url()
         reset_url = f"{manager_url}/Actions/Manager.Reset"
-        request = Request(reset_url, headers=self.headers, method='POST', data=json.dumps({}).encode('utf-8'))
+        request = Request(reset_url, headers=self.headers, method='POST',
+                          data=json.dumps({"ResetType": "GracefulRestart"}).encode('utf-8'))
         urlopen(request, context=self.context)
 
     def set_iso(self, iso_url):


### PR DESCRIPTION
For resetting IDRAC the URL must include {"ResetType": "GracefulRestart"} post body.
With empty body it get 400 Error