### PR TITLE
Take the only first element when discovering an interface

### DIFF
--- a/kvirt/openshift/__init__.py
+++ b/kvirt/openshift/__init__.py
@@ -1229,7 +1229,7 @@ def create(config, plandir, cluster, overrides, dnsconfig=None):
                     call(f"sudo chown apache.apache {baremetal_web_dir}/{cluster}-sno.iso", shell=True)
             else:
                 call(f"sudo chmod a+r {iso_pool_path}/{cluster}-sno.iso", shell=True)
-            nic = os.popen('ip r | grep default | cut -d" " -f5').read().strip()
+            nic = os.popen('ip r | grep default | cut -d" " -f5 | head -1').read().strip()
             ip_cmd = f"ip -o addr show {nic} | awk '{{print $4}}' | cut -d '/' -f 1 | head -1"
             host_ip = os.popen(ip_cmd).read().strip()
             if baremetal_web_port != 80:


### PR DESCRIPTION
Prevent cases when ip route has a few default routes like: default via 10.x.x.x dev baremetal
default via 10.x.x.x dev baremetal proto dhcp src 10.x.x.x metric 425