### PR TITLE
Add rocky linux 9.1 to the list of images

### DIFF
--- a/kvirt/defaults.py
+++ b/kvirt/defaults.py
@@ -127,6 +127,7 @@ IMAGES = {'almalinux9': 'http://repo.ifca.es/almalinux/9.0/cloud/x86_64/images/'
           'rockylinux86': ROCKY + '8.6/images/Rocky-8-GenericCloud.latest.x86_64.qcow2',
           'rockylinux8': ROCKY + '8/images/Rocky-8-GenericCloud.latest.x86_64.qcow2',
           'rockylinux90': ROCKY + '9.0/images/x86_64/Rocky-9-GenericCloud.latest.x86_64.qcow2',
+          'rockylinux91': ROCKY + '9.1/images/x86_64/Rocky-9-GenericCloud.latest.x86_64.qcow2',
           'rockylinux9': ROCKY + '9/images/x86_64/Rocky-9-GenericCloud.latest.x86_64.qcow2'}
 
 IMAGESCOMMANDS = {'debian8': 'echo datasource_list: [NoCloud, ConfigDrive, Openstack, Ec2] > /etc/cloud/cloud.cfg.d/'


### PR DESCRIPTION
```
$ kcli download image rockylinux91
Using pool default
Using url https://dl.rockylinux.org/pub/rocky/9.1/images/x86_64/Rocky-9-GenericCloud.latest.x86_64.qcow2...
Grabbing image rockylinux91...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  880M  100  880M    0     0  4440k      0  0:03:22  0:03:22 --:--:-- 4091k
Image rockylinux91 Added
Adding a profile named local_rockylinux91 with default values
```