### PR TITLE
Add domain to type loadbalancer in libvirt

### DIFF
--- a/kvirt/config.py
+++ b/kvirt/config.py
@@ -2567,7 +2567,14 @@ class Kconfig(Kbaseconfig):
                     else:
                         break
                 vminfo.append({'name': vm, 'ip': ip})
-            overrides = {'name': name, 'vms': vminfo, 'nets': nets, 'ports': ports, 'checkpath': checkpath}
+            overrides = {
+                "name": name,
+                "vms": vminfo,
+                "nets": nets,
+                "ports": ports,
+                "checkpath": checkpath,
+                "domain": domain,
+            }
             self.plan(plan, inputstring=haproxyplan, overrides=overrides)
 
     def list_loadbalancers(self):

--- a/kvirt/internalplans/__init__.py
+++ b/kvirt/internalplans/__init__.py
@@ -5,6 +5,7 @@ parameters:
  nets:
  - default
  vms: []
+ domain:
 
 {{ image }}:
  type: image
@@ -16,6 +17,9 @@ loadbalancer-{{ ports | join('+') }}:
 
 {{ name }}:
  profile: loadbalancer-{{ ports | join('+') }}
+ {% if domain != None %}
+ domain: {{ domain }}
+ {% endif %}
  files:
   - path: /root/haproxy.cfg
     content:   |


### PR DESCRIPTION
This change preserves the old behavior if domain is not specified and allows to specify a domain explicitly.

I need the domain field because some modern distributions such as fedora 37 and ubuntu 22.04 will not resolve the name of the host unless the host has a domain.