### PR TITLE
kvm: added option for network domain zone query forward

### DIFF
--- a/kvirt/providers/kvm/__init__.py
+++ b/kvirt/providers/kvm/__init__.py
@@ -3259,10 +3259,13 @@ class Kvirt(object):
             natxml = "<forward mode='nat'><nat><port start='1024' end='65535'/></nat></forward>"
         else:
             natxml = ''
+        localdomain = "no"
+        if 'localdomain' in overrides and overrides['localdomain']:
+            localdomain = "yes"
         if domain is not None:
-            domainxml = f"<domain name='{domain}'/>"
+            domainxml = f"<domain name='{domain}' localOnly='{localdomain}'/>"
         else:
-            domainxml = f"<domain name='{name}'/>"
+            domainxml = f"<domain name='{name}' localOnly='{localdomain}'/>"
         if len(name) < 16:
             bridgename = name if name != 'default' else 'virbr0'
             bridgexml = f"<bridge name='{bridgename}' stp='on' delay='0'/>"


### PR DESCRIPTION
When using host side lookup of vm hostnames for example via systemd-resolve domain requests to the desired network domain will always be forwarded upstream. this causes slow dns querys on host. To prevent upstream dns forward libvirt can set `localOnly` in the network config. This should be the default in most cases when you work with network domains in libvirt. So my suggestion is to add a network flag `localdomain` which controls upstream forward behaviour