### PR TITLE
Exclude podman interface from primary nic search

### DIFF
--- a/kvirt/cluster/microshift/scripts/00_sslip.sh
+++ b/kvirt/cluster/microshift/scripts/00_sslip.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-PRIMARY_NIC=$(ls -1 /sys/class/net | head -1)
+PRIMARY_NIC=$(ls -1 /sys/class/net | grep -v podman | head -1)
 IP=$(ip -o addr show $PRIMARY_NIC | head -1 | awk '{print $4}' | cut -d'/' -f1)
 NEW_NAME=$(echo $IP | sed 's/\./-/g' | sed 's/:/-/g').sslip.io
 hostnamectl set-hostname $NEW_NAME

--- a/kvirt/cluster/openshift/99-localhost-fix.yaml
+++ b/kvirt/cluster/openshift/99-localhost-fix.yaml
@@ -21,7 +21,7 @@ spec:
           [Service]
           Type=oneshot
           ExecStart=/bin/bash -c "if [[ $(hostname) == *localhost* ]]; then \
-             PRIMARY_NIC=$(ls -1 /sys/class/net | head -1) ;\
+             PRIMARY_NIC=$(ls -1 /sys/class/net | grep -v podman | head -1) ;\
              HOSTNAME=$(ip a l $PRIMARY_NIC | grep link | awk '{print $2}' | sed 's/:/-/g') ;\
              echo $HOSTNAME > /etc/hostname ;\
              nmcli general hostname $HOSTNAME ;\


### PR DESCRIPTION
When searching for primary nic and podman is running in this time there is network interface cni-podman0 created and it's choosen as a primary nic. Which is wrong, so exclude it specifically.

See also https://github.com/karmab/kcli-openshift4-baremetal/pull/124