### PR TITLE
Lookup the right key in vm_ports

### DIFF
--- a/kvirt/providers/gcp/__init__.py
+++ b/kvirt/providers/gcp/__init__.py
@@ -910,8 +910,8 @@ class Kgcp(object):
             error(f"VM {name} not found")
             return []
         for interface in vm['networkInterfaces']:
-            if 'subnet' in interface:
-                subnets.append(os.path.basename(interface['subnet']))
+            if 'subnetwork' in interface:
+                subnets.append(os.path.basename(interface['subnetwork']))
         return subnets
 
     def get_pool_path(self, pool):


### PR DESCRIPTION
An incorrect key was used when looking up a VM networkinterface in vm_ports(). This caused the function to incorrectly return no subnets in the case where there actually are VPC shared network subnets "on" a VM.