### PR TITLE
No gcp-hack when an internal LB is in play on GCP

### DIFF
--- a/kvirt/cluster/k3s/bootstrap.sh
+++ b/kvirt/cluster/k3s/bootstrap.sh
@@ -6,7 +6,7 @@
 apt-get -y install curl
 {% endif %}
 
-{% if config_type == 'gcp' %}
+{% if config_type == 'gcp' and not cloud_api_internal %}
 systemctl enable --now gcp-hack
 ufw allow from any to any port 6443,2379,2380 proto tcp
 {% endif %}

--- a/kvirt/cluster/k3s/bootstrap.yml
+++ b/kvirt/cluster/k3s/bootstrap.yml
@@ -6,7 +6,7 @@
 
 {% set all_files = files|default([]) %}
 {% set all_scripts = ["bootstrap.sh"] %}
-{% if config_type not in ['aws', 'gcp', 'ibm'] and api_ip != None %}
+{% if config_type not in ['aws', 'gcp', 'ibm'] and api_ip != None and not cloud_api_internal %}
 {% do all_files.append("keepalived.conf") %}
 {% do all_scripts.append("keepalived.sh") %}
 {% endif %}

--- a/kvirt/cluster/k3s/ctlplanes.sh
+++ b/kvirt/cluster/k3s/ctlplanes.sh
@@ -2,7 +2,7 @@
 {% set extra_args = extra_ctlplane_args %}
 {% endif %}
 
-{% if config_type == 'gcp' %}
+{% if config_type == 'gcp' and not cloud_api_internal %}
 systemctl enable --now gcp-hack
 ufw allow from any to any port 6443,2379,2380 proto tcp
 {% endif %}

--- a/kvirt/cluster/k3s/ctlplanes.yml
+++ b/kvirt/cluster/k3s/ctlplanes.yml
@@ -12,7 +12,7 @@
 {% if config_type not in ['aws', 'gcp', 'ibm'] and api_ip != None %}
 {% do all_files.append("keepalived.conf") %}
 {% do all_scripts.append("keepalived.sh") %}
-{% elif config_type == 'gcp' %}
+{% elif config_type == 'gcp' and not cloud_api_internal %}
 {% do all_files.append({"path" : "/usr/local/bin/gcp-hack.sh", "origin": 'gcp-hack.sh', "mode": 755}) %}
 {% do all_files.append({"path" : "/usr/lib/systemd/system/gcp-hack.service", "origin": 'gcp-hack.service', "mode": 644}) %}
 {% endif %}

--- a/kvirt/cluster/k3s/workers.sh
+++ b/kvirt/cluster/k3s/workers.sh
@@ -1,4 +1,4 @@
-{% if config_type == 'gcp' %}
+{% if config_type == 'gcp' and not cloud_api_internal %}
 systemctl enable --now gcp-hack
 {% endif %}
 {% if 'ubuntu' in image %}

--- a/kvirt/cluster/k3s/workers.yml
+++ b/kvirt/cluster/k3s/workers.yml
@@ -19,7 +19,7 @@
  disks: {{ [disk_size] + extra_disks }}
  files:
  - join.sh
-{% if config_type == 'gcp' %}
+{% if config_type == 'gcp' and not cloud_api_internal %}
  - path: /usr/local/bin/gcp-hack.sh
    origin: gcp-hack.sh
    mode: 755


### PR DESCRIPTION
If we can I want us to avoid the use of the GCP hack when an internal LB is in play. This should do just that.