### PR TITLE
Fix getting objects by name

### DIFF
--- a/kvirt/cli.py
+++ b/kvirt/cli.py
@@ -733,8 +733,8 @@ def _list_output(_list, output):
         print(json.dumps(_list, indent=2))
     elif output == 'name':
         if isinstance(_list, list):
-            for entry in sorted(_list, key=lambda x: x['name']):
-                print(entry['name'])
+            for entry in sorted(_list):
+                print(entry)
         else:
             for key in sorted(list(_list.keys())):
                 print(key)


### PR DESCRIPTION
When getting objects by name, the below error is observed.

```
-> kcli list images -o name
Traceback (most recent call last):
  File "/usr/bin/kcli", line 33, in <module>
    sys.exit(load_entry_point('kcli==99.0', 'console_scripts', 'kcli')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/kvirt/cli.py", line 5119, in cli
    args.func(args)
  File "/usr/lib/python3.11/site-packages/kvirt/cli.py", line 1127, in list_image
    _list_output(images, output)
  File "/usr/lib/python3.11/site-packages/kvirt/cli.py", line 737, in _list_output
    print(entry['name'])
          ~~~~~^^^^^^^^
TypeError: string indices must be integers, not 'str'
```