### PR TITLE
proxmox: add iso support

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -594,6 +594,7 @@ The following parameters are specific to proxmox:
 - `auth_token_name` and `auth_token_secret` (Optional). API Token used for authentification instead of password.
 - `filtertag` (Optional). Only manage VMs created by kcli with the corresponding tag.
 - `node` (Optional). Create VMs on specified PVE node in case of Proxmox cluster.
+- `imagepool` (Optional). Storage pool for images and ISOs.
 - `verify_ssl` (Optional). Enable/Disable SSL verification. Default to True.
 
 Note that uploading images and cloud-init/ignition files requires ssh access to the Proxmox host. It's highly recommended to configure passwordless ssh authentification.

--- a/kvirt/baseconfig.py
+++ b/kvirt/baseconfig.py
@@ -1852,7 +1852,14 @@ class Kbaseconfig:
             currentconfpool = self.confpools[confpool]
             ip_reservations = currentconfpool.get('ip_reservations', {})
             reserved_ips = list(ip_reservations.values())
-            if 'ips' in currentconfpool and self.type in ['kvm', 'kubevirt', 'ovirt', 'openstack', 'vsphere']:
+            if "ips" in currentconfpool and self.type in [
+                "kvm",
+                "kubevirt",
+                "ovirt",
+                "openstack",
+                "vsphere",
+                "proxmox",
+            ]:
                 ips = currentconfpool['ips']
                 if '/' in ips:
                     ips = [str(i) for i in ip_network(ips)[1:.1]]

--- a/kvirt/common/__init__.py
+++ b/kvirt/common/__init__.py
@@ -1945,6 +1945,7 @@ def generate_rhcos_iso(k, cluster, pool, version='latest', podman=False, install
     kubevirt = 'kubevirt' in str(type(k))
     openstack = 'openstack' in str(type(k))
     vsphere = 'vsphere' in str(type(k))
+    proxmox = 'proxmox' in str(type(k))
     name = f'{cluster}-iso' if kubevirt else f'{cluster}.iso'
     if name in [os.path.basename(iso) for iso in k.volumes(iso=True)]:
         warning(f"Deleting old iso {name}")
@@ -1957,16 +1958,18 @@ def generate_rhcos_iso(k, cluster, pool, version='latest', podman=False, install
         k.patch_pvc(pvc, isocmd, image="quay.io/coreos/coreos-installer:release", files=['iso.ign'])
         k.update_cdi_endpoint(pvc, f'{cluster}.iso')
         return
-    if openstack or vsphere:
+    if openstack or vsphere or proxmox:
         pprint(f"Creating iso {name}")
         baseisocmd = f"curl -L {liveiso} -o /tmp/{os.path.basename(liveiso)}"
         call(baseisocmd, shell=True)
         copy2('iso.ign', '/tmp')
         isocmd = create_embed_ignition_cmd(name, '/tmp', baseiso, podman=podman, extra_args=extra_args)
         os.system(isocmd)
-        k.add_image(f'/tmp/{name}', pool, name=name)
+        result = k.add_image(f'/tmp/{name}', pool, name=name)
         os.remove(f'/tmp/{os.path.basename(liveiso)}')
         os.remove(f'/tmp/{name}')
+        if result['result'] != 'success':
+            error(result['reason'])
         return
     if baseiso not in k.volumes(iso=True):
         pprint(f"Downloading {liveiso}")

--- a/kvirt/config.py
+++ b/kvirt/config.py
@@ -366,6 +366,7 @@ class Kconfig(Kbaseconfig):
                     error("Missing auth_token_secret in the configuration. Leaving")
                     sys.exit(1)
                 filtertag = self.options.get('filtertag')
+                imagepool = self.options.get('imagepool')
                 node = self.options.get('node')
                 verify_ssl = self.options.get('verify_ssl')
                 try:
@@ -382,6 +383,7 @@ class Kconfig(Kbaseconfig):
                     filtertag=filtertag,
                     node=node,
                     verify_ssl=verify_ssl,
+                    imagepool=imagepool,
                     debug=False)
             elif self.type == 'web':
                 port = self.options.get('port', 8000)


### PR DESCRIPTION
tested with `sno=True` deployment.

Note that I added this part to instantiate the SNO VM at cluster creation automatically:
(This is **not included in this PR** as I'm unsure if this is something you want)
```diff
diff --git a/kvirt/cluster/openshift/__init__.py b/kvirt/cluster/openshift/__init__.py
index 90ae3882..27b039f1 100755
--- a/kvirt/cluster/openshift/__init__.py
+++ b/kvirt/cluster/openshift/__init__.py
@@ -1406,6 +1406,11 @@ def create(config, plandir, cluster, overrides, dnsconfig=None):
                           'prometheus-k8s-openshift-monitoring.apps']
             dnsentry = ' '.join([f"{entry}.{cluster}.{domain}" for entry in dnsentries])
             warning(f"$your_node_ip {dnsentry}")
+        if config.type == 'proxmox':
+            pprint(f"Creating {sno_name} vm...")
+            result = config.plan(plan, inputfile=f'{plandir}/sno.yml', overrides=overrides)
+            if result['result'] != 'success':
+                error(result['reason']) 
         if baremetal_hosts:
             iso_pool = data['pool'] or config.pool
             iso_url = handle_baremetal_iso_sno(config, plandir, cluster, data, baremetal_hosts, iso_pool)
```