### PR TITLE
kube generic: Fix network=None when no api_ip provided

### DIFF
--- a/kvirt/cluster/kubeadm/__init__.py
+++ b/kvirt/cluster/kubeadm/__init__.py
@@ -110,7 +110,6 @@ def create(config, plandir, cluster, overrides):
         domain = data.get('domain', 'karmalabs.corp')
         api_ip = f"{cluster}-ctlplane.{domain}"
     elif api_ip is None:
-        network = data.get('network')
         networkinfo = k.info_network(network)
         if not networkinfo:
             msg = f"Issue getting network {network}"


### PR DESCRIPTION
Hi, I was the one that had the weird environment config that prompted 0160f70, but I think the fix might have a minor error.

0160f70 got rid of the assumption that the default api_ip would always be 192.168.12.253.

However, an extra network=data.get('network') without a 'default' always set the network as None, which fails with
    `
    Network None not found
    Issue getting network None
    `
when kube create kube generic is run, as network is not defined in data above.

network is already set above a few lines before with

    network = data.get('network', 'default')
    
and none of the code in between seems to update data, so, I think its safe to just delete it.

edit: closed then opened because I was checking that overrides was not adding a network field.