### PR TITLE
make kcli capable to download ppc64le cloud image

### DIFF
--- a/kvirt/cli.py
+++ b/kvirt/cli.py
@@ -4574,7 +4574,7 @@ def cli():
     images_list = '\n'.join(IMAGES.keys())
     imagedownload_help = f"Image to download. Choose between \n{images_list}"
     imagedownload_parser = argparse.ArgumentParser(add_help=False)
-    imagedownload_parser.add_argument('-a', '--arch', help='Target arch', choices=['x86_64', 'aarch64'],
+    imagedownload_parser.add_argument('-a', '--arch', help='Target arch', choices=['x86_64', 'aarch64', 'ppc64le'],
                                       default='x86_64')
     imagedownload_parser.add_argument('-c', '--cmd', help='Extra command to launch after downloading', metavar='CMD')
     imagedownload_parser.add_argument('-i', '--installer', help='Get rhcos url from openshift-installer',


### PR DESCRIPTION
Currently kcli only suppport x86_64 and aarch, after change this limitation, "kcli download image CentOS-8 -a ppc64le -u https://cloud.centos.org/centos/8/ppc64le/images/Ce ntOS-8-GenericCloud-8.4.2105-20210603.0.ppc64le.qcow2" works on my ppc64le linux system.