### PR TITLE
[K3s] - Always use the `--tls-san` parameter on k3s server instances

### DIFF
--- a/kvirt/cluster/k3s/bootstrap.sh
+++ b/kvirt/cluster/k3s/bootstrap.sh
@@ -7,7 +7,7 @@ apt-get -y install curl
 {% endif %}
 
 export IP={{ api_ip if cloud_lb else "$(curl -s ifconfig.me)" if config_type in ['aws', 'gcp', 'ibmcloud'] else '$(hostname -I | cut -f1 -d" ")' }}
-curl -sfL https://get.k3s.io | {{ install_k3s_args }} K3S_TOKEN={{ token }} sh -s - server {{ '--cluster-init' if ctlplanes > 1 else '' }} {{ extra_args|join(" ") }} {{ '--tls-san $IP' if not cloud_lb and config_type in ['aws', 'gcp', 'ibmcloud'] else '' }}
+curl -sfL https://get.k3s.io | {{ install_k3s_args }} K3S_TOKEN={{ token }} sh -s - server {{ '--cluster-init' if ctlplanes > 1 else '' }} {{ extra_args|join(" ") }} {{ '--tls-san $IP' }}
 export K3S_TOKEN=$(cat /var/lib/rancher/k3s/server/node-token)
 sed "s/127.0.0.1/$IP/" /etc/rancher/k3s/k3s.yaml > /root/kubeconfig
 if [ -d /root/manifests ] ; then

--- a/kvirt/cluster/k3s/ctlplanes.sh
+++ b/kvirt/cluster/k3s/ctlplanes.sh
@@ -9,4 +9,4 @@ apt-get -y install curl
 echo bpffs /sys/fs/bpf bpf defaults 0 0 >> /etc/fstab
 mount /sys/fs/bpf
 {% endif %}
-curl -sfL https://get.k3s.io | {{ install_k3s_args|default("") }} K3S_TOKEN={{ token }} sh -s - server --server https://{{ first_ip }}:6443 {{ extra_args|join(" ") }}
+curl -sfL https://get.k3s.io | {{ install_k3s_args|default("") }} K3S_TOKEN={{ token }} sh -s - server --server https://{{ first_ip }}:6443 {{ extra_args|join(" ") }} --tls-san {{ first_ip }}


### PR DESCRIPTION
We've been back and forth on the consequences of https://github.com/k3s-io/k3s/security/advisories/GHSA-m4hf-6vgr-75r2 over on the KCLI Slack Kubernetes community channel.

Adding the `--tls-san` parameter to all scripts bootstrapping K3s server nodes is, according to my understanding, needed.

This PR accomplishes:

- The use of --tls-san` in the `kcli scale` case and
- When deploying a fresh cluster with e.g. `kcli create`

For `K3s` version < v1.28, they should be all good with this. 

---

In the one `control-plane node` `K3s cluster`. I don't think there's an issue.

---

Alright. Thank you.