### PR TITLE
Update index.md - incorrect command

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -179,7 +179,7 @@ kcli create host kvm -H 127.0.0.1 local
 Or indicate a different target host:
 
 ```Shell
-kcli create host -H 192.168.0.6 host1
+kcli create host kvm -H 192.168.0.6 host1
 ```
 
 On most distributions, default network and storage pool for Libvirt are already defined.


### PR DESCRIPTION
- missing the `kvm` when creating a remote host

- Docs use `kcli create host -H 192.168.0.6 host1` as an example for creating a remote host.
- It should be `kcli create host kvm -H 192.168.0.6 host1`