### PR TITLE
kvm: fix issue report from Ubuntu22.04 s390x host

### DIFF
--- a/kvirt/providers/kvm/__init__.py
+++ b/kvirt/providers/kvm/__init__.py
@@ -862,7 +862,7 @@ class Kvirt(object):
                                     combustion=combustion)
                     self._uploadimage(name, pool=default_storagepool, origin=tmpdir)
         listen = '0.0.0.0' if self.host not in ['localhost', '127.0.0.1'] else '127.0.0.1'
-        if aarch64:
+        if aarch64 or as390x:
             displayxml = ''
             display = 'vnc'
         else:


### PR DESCRIPTION
- 'ps2 is not supported by this QEMU binary'

https://github.com/confidential-containers/cloud-api-adaptor/pull/1597#issuecomment-1824624151