### PR TITLE
Fix SNO bug

### DIFF
--- a/kvirt/cluster/openshift/sno-finish.sh
+++ b/kvirt/cluster/openshift/sno-finish.sh
@@ -15,7 +15,7 @@ install_device=$(lsblk -r | grep rhcos | head -1 | cut -d" " -f1 | sed 's/[0-9]\
 if [ -z $install_device ] ; then
 install_device=$(lsblk | grep disk | head -1 | cut -d" " -f1)
 fi
-install_device=/dev/$(install_device)
+install_device=/dev/$install_device
 {% endif %}
 if [ ! -b $install_device ]; then
   echo "Can't find appropriate device to install to. $install_device not found"


### PR DESCRIPTION
**install_device** is being read as a command instead of a var, so this script fails. 

By removing the parenthesis its taking as a variable and the installation completes successfully. 
