### PR TITLE
Fixes the ctlplane-0 scale case and also improves the logic around what value is given to $IP that's passed to the --tls-san parameter.

### DIFF
--- a/kvirt/cluster/k3s/bootstrap.sh
+++ b/kvirt/cluster/k3s/bootstrap.sh
@@ -6,8 +6,29 @@
 apt-get -y install curl
 {% endif %}
 
-export IP={{ api_ip if cloud_lb else "$(curl -s ifconfig.me)" if config_type in ['aws', 'gcp', 'ibmcloud'] else '$(hostname -I | cut -f1 -d" ")' }}
-curl -sfL https://get.k3s.io | {{ install_k3s_args }} K3S_TOKEN={{ token }} sh -s - server {{ '--cluster-init' if ctlplanes > 1 else '' }} {{ extra_args|join(" ") }} {{ '--tls-san $IP' }}
+{% if config_type == 'gcp' %}
+systemctl enable --now gcp-hack
+ufw allow from any to any port 6443,2379,2380 proto tcp
+{% endif %}
+
+# The logic below is to achieve the following
+# - for cloud providers. If the API is internal and
+# this is a HA cluster. Use the IP of the API load-balancer
+# - for cloud providers. If the API is NOT internal.
+# use the external IP. This in both the HA and single ctlplane case
+# - The last to branches is for on-prem. E.g. vSphere/VMWare
+# in HA or single ctlplane scenarios.
+{% if cloud_api_internal and ctlplanes > 1 %}
+export IP={{ api_ip }}
+{% elif config_type in ['aws', 'gcp', 'ibmcloud'] %}
+export IP={{ "$(curl -s ifconfig.me)" }}
+{% elif ctlplanes > 1 %}
+export IP={{ api_ip }}
+{% else %}
+export IP={{ first_ip }}
+{% endif %}
+
+curl -sfL https://get.k3s.io | {{ install_k3s_args }} K3S_TOKEN={{ token }} sh -s - server {{ '--cluster-init' if ctlplanes > 1 else '' }} {{ extra_args|join(" ") }} {{ '--tls-san $IP' if not cloud_lb and config_type in ['aws', 'gcp', 'ibmcloud'] else '' }}
 export K3S_TOKEN=$(cat /var/lib/rancher/k3s/server/node-token)
 sed "s/127.0.0.1/$IP/" /etc/rancher/k3s/k3s.yaml > /root/kubeconfig
 if [ -d /root/manifests ] ; then

--- a/kvirt/cluster/k3s/bootstrap.sh
+++ b/kvirt/cluster/k3s/bootstrap.sh
@@ -6,11 +6,6 @@
 apt-get -y install curl
 {% endif %}
 
-{% if config_type == 'gcp' %}
-systemctl enable --now gcp-hack
-ufw allow from any to any port 6443,2379,2380 proto tcp
-{% endif %}
-
 # The logic below is to achieve the following
 # - for cloud providers. If the API is internal and
 # this is a HA cluster. Use the IP of the API load-balancer

--- a/kvirt/cluster/k3s/ctlplanes.sh
+++ b/kvirt/cluster/k3s/ctlplanes.sh
@@ -1,5 +1,3 @@
-
-
 {% if extra_ctlplane_args %}
 {% set extra_args = extra_ctlplane_args %}
 {% endif %}
@@ -12,5 +10,26 @@ echo bpffs /sys/fs/bpf bpf defaults 0 0 >> /etc/fstab
 mount /sys/fs/bpf
 {% endif %}
 
-export IP={{ api_ip if cloud_lb else "$(curl -s ifconfig.me)" if config_type in ['aws', 'gcp', 'ibmcloud'] else first_ip }}
+# The logic below is to achieve the following
+# - for cloud providers. If the API is internal and
+# this is a HA cluster. Use the IP of the API load-balancer
+# - for cloud providers. If the API is NOT internal.
+# use the external IP. This in both the HA and single ctlplane case
+# - The last to branches is for on-prem. E.g. vSphere/VMWare
+# in HA or single ctlplane scenarios.
+{% if cloud_api_internal and ctlplanes > 1 %}
+export IP={{ api_ip }}
+{% elif config_type in ['aws', 'gcp', 'ibmcloud'] %}
+export IP={{ "$(curl -s ifconfig.me)" }}
+{% elif ctlplanes > 1 %}
+export IP={{ api_ip }}
+{% else %}
+export IP={{ first_ip }}
+{% endif %}
+
+# In the case that we're scaling back in ctlplane-0 we need to use another one of
+# the ctlplane's as the node to join for ctlplane-0. As ctlplane-0 obviously
+# cannot join the cluster 'via' itself.
+{% set first_ip = '{0}-ctlplane-1'.format(cluster)|kcli_info('ip', client ) if scale|default(False) and 'ctlplane-0' in name else first_ip %}
+
 curl -sfL https://get.k3s.io | {{ install_k3s_args|default("") }} K3S_TOKEN={{ token }} sh -s - server --server https://{{ first_ip }}:6443 {{ extra_args|join(" ") }} --tls-san $IP


### PR DESCRIPTION
We've been back and forth on this and I think this is an improvement for the following reasons.

- First of, I've now tried multiple times to remove ctlplane-0 and add it back again by running e.g.: `kcli --client CLIENT_NAME scale kube k3s --paramfile ./PARAM_FILEE.yml -P workers=3 -P ctlplanes=3 CLUSTER_NAME`. The changes in this PR works. When I say works I mean that `ctlplane-0` being scaled actually joins the cluster and have the correct value ( ip ) to the `server` parameter for the `K3s` install. As well as the `$IP` variable to the `--tls-san` parameter gets the correct value.

- While debugging the scenario of scaling back in the ctlplane-0 node I noticed that `cloud_lb` was always `False` in the `ctlplanes.sh` script. This is because:

```python
data['cloud_lb'] = cloud_lb
```

is never done after:

```python
cloud_lb = data.get('cloud_lb', provider in cloud_providers and data['ctlplanes'] > 1)
```

Is executed at LOC 56 in `__init__.py` for the `K3s` cluster type.

So the changes here fixes that the IP in the case that `GCP` is used and a HA cluster is in play ( so API_IP set ). The value that the `$IP` variable got was always an external ip from the result of `"$(curl -s ifconfig.me)"`.

---

Then when looking harder at this I wondered why use the `cloud_lb` variable and not `cloud_api_internal` which seems better equipped. Better logically named considering that we're trying to set the value to `$IP` depending on exactly whether the cluster pi is exposed to the Internet or not.

So that's why I changed to that `variable` instead of `cloud_lb`.

---

Then further. We have to set `first_ip` to the `IP` of another ctlplane in the case that we're scaling in `ctlplane-0`. If we don't `ctlplane-0` will try to join the cluster by communicating with itself and that'll never get anywhere. As in the `join.sh` `Bash script` `first_ip` is only updated in the case that we're scaling and the ctlplane being scaled in is `ctlplane-0`.

---

I'm runing the full logic we have for our Platform ( Kubernemlig ) when we interchange nodes by wrapping `kcli scale` .. to fully vet the above in the case that the ctlplane being scaled in is **NOT** the `ctlplane-0` node. Things are looking good.

So here we go.