### PR TITLE
Replace distutils.version with packaging.version for python 3.12

### DIFF
--- a/.github/cloudsmith.sh
+++ b/.github/cloudsmith.sh
@@ -15,7 +15,7 @@ export MINOR=$(date "+%Y%m%d%H%M").$(git rev-parse --short HEAD)
 find . -name *pyc -exec rm {} \;
 GIT_VERSION="$(git ls-remote https://github.com/karmab/kcli | head -1 | cut -c1-7) $(date +%Y/%m/%d)"
 echo $GIT_VERSION > kvirt/version/git
-python3 setup.py --command-packages=stdeb.command sdist_dsc --debian-version $MINOR --depends python3-dateutil,python3-prettytable,python3-libvirt,genisoimage,python3-distutils,git bdist_deb
+python3 setup.py --command-packages=stdeb.command sdist_dsc --debian-version $MINOR --depends python3-dateutil,python3-prettytable,python3-libvirt,genisoimage,git bdist_deb
 deb=$(realpath $(find . -name *.deb))
 
 # ugly fix for unknown compression for member 'control.tar.zst'

--- a/.github/cloudsmith.sh
+++ b/.github/cloudsmith.sh
@@ -15,7 +15,7 @@ export MINOR=$(date "+%Y%m%d%H%M").$(git rev-parse --short HEAD)
 find . -name *pyc -exec rm {} \;
 GIT_VERSION="$(git ls-remote https://github.com/karmab/kcli | head -1 | cut -c1-7) $(date +%Y/%m/%d)"
 echo $GIT_VERSION > kvirt/version/git
-python3 setup.py --command-packages=stdeb.command sdist_dsc --debian-version $MINOR --depends python3-dateutil,python3-prettytable,python3-libvirt,genisoimage,git bdist_deb
+python3 setup.py --command-packages=stdeb.command sdist_dsc --debian-version $MINOR --depends python3-dateutil,python3-prettytable,python3-libvirt,python-setuptools,genisoimage,git bdist_deb
 deb=$(realpath $(find . -name *.deb))
 
 # ugly fix for unknown compression for member 'control.tar.zst'

--- a/.github/cloudsmith_snapshot.sh
+++ b/.github/cloudsmith_snapshot.sh
@@ -16,7 +16,7 @@ export MINOR=0
 find . -name *pyc -exec rm {} \;
 GIT_VERSION="$(curl -s https://github.com/karmab/kcli/commits/main | jq -r .payload.commitGroups[0].commits[0].oid | cut -c1-8) $(date +%Y/%m/%d)"
 echo $GIT_VERSION > kvirt/version/git
-python3 setup.py --command-packages=stdeb.command sdist_dsc --debian-version $MINOR --depends python3-dateutil,python3-prettytable,python3-flask,python3-libvirt,python3-requests,genisoimage,python3-distutils,jq bdist_deb
+python3 setup.py --command-packages=stdeb.command sdist_dsc --debian-version $MINOR --depends python3-dateutil,python3-prettytable,python3-flask,python3-libvirt,python3-requests,genisoimage,jq bdist_deb
 deb=$(realpath $(find . -name *.deb))
 
 # ugly fix for unknown compression for member 'control.tar.zst', giving up

--- a/.github/cloudsmith_snapshot.sh
+++ b/.github/cloudsmith_snapshot.sh
@@ -16,7 +16,7 @@ export MINOR=0
 find . -name *pyc -exec rm {} \;
 GIT_VERSION="$(curl -s https://github.com/karmab/kcli/commits/main | jq -r .payload.commitGroups[0].commits[0].oid | cut -c1-8) $(date +%Y/%m/%d)"
 echo $GIT_VERSION > kvirt/version/git
-python3 setup.py --command-packages=stdeb.command sdist_dsc --debian-version $MINOR --depends python3-dateutil,python3-prettytable,python3-flask,python3-libvirt,python3-requests,genisoimage,jq bdist_deb
+python3 setup.py --command-packages=stdeb.command sdist_dsc --debian-version $MINOR --depends python3-dateutil,python3-prettytable,python3-flask,python3-libvirt,python3-requests,python-setuptools,genisoimage,jq bdist_deb
 deb=$(realpath $(find . -name *.deb))
 
 # ugly fix for unknown compression for member 'control.tar.zst', giving up

--- a/.github/prep.sh
+++ b/.github/prep.sh
@@ -1,6 +1,6 @@
 apt-get update
-apt-get -y install python3-pip python3-wheel python3-setuptools python3-all python3-distutils dh-python debhelper build-essential fakeroot libkrb5-dev binutils
-pip3 install misspellings cloudsmith-cli pycodestyle stdeb copr-cli
+apt-get -y install python3-pip python3-wheel python3-setuptools python3-all dh-python debhelper build-essential fakeroot libkrb5-dev binutils
+pip3 install misspellings cloudsmith-cli pycodestyle stdeb copr-cli packaging
 pip3 install -U Jinja2
 apt-get -y install libvirt-daemon libvirt0 qemu-system-x86 qemu-utils qemu-kvm libvirt-daemon-system curl genisoimage python3-libvirt qemu-user-static podman
 setfacl -m u:runner:rwx /var/run/libvirt/libvirt-sock

--- a/.github/prep.sh
+++ b/.github/prep.sh
@@ -1,6 +1,6 @@
 apt-get update
 apt-get -y install python3-pip python3-wheel python3-setuptools python3-all dh-python debhelper build-essential fakeroot libkrb5-dev binutils
-pip3 install misspellings cloudsmith-cli pycodestyle stdeb copr-cli packaging
+pip3 install misspellings cloudsmith-cli pycodestyle stdeb copr-cli
 pip3 install -U Jinja2
 apt-get -y install libvirt-daemon libvirt0 qemu-system-x86 qemu-utils qemu-kvm libvirt-daemon-system curl genisoimage python3-libvirt qemu-user-static podman
 setfacl -m u:runner:rwx /var/run/libvirt/libvirt-sock

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,4 @@ sphinx
 pdoc3
 pydata_sphinx_theme
 sphinx_rtd_theme
-
+packaging

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,4 @@ sphinx
 pdoc3
 pydata_sphinx_theme
 sphinx_rtd_theme
-packaging
+

--- a/kcli.spec
+++ b/kcli.spec
@@ -16,7 +16,7 @@ Source:         {{{ git_dir_pack }}}
 AutoReq:        no
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  python3-devel rubygem-ronn gzip python3-setuptools git
-Requires:       python3 libvirt-python3 genisoimage nmap-ncat python3-prettytable python3-jinja2 python3-PyYAML python3-argcomplete
+Requires:       python3 libvirt-python3 genisoimage nmap-ncat python3-prettytable python3-jinja2 python3-PyYAML python3-argcomplete python3-packaging
 
 %description
 Kcli is a wrapper for local/remote libvirt, aws, azure, gcp, kubevirt, ovirt, openstack, packet, proxmox and vsphere

--- a/kcli.spec
+++ b/kcli.spec
@@ -16,7 +16,7 @@ Source:         {{{ git_dir_pack }}}
 AutoReq:        no
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  python3-devel rubygem-ronn gzip python3-setuptools git
-Requires:       python3 libvirt-python3 genisoimage nmap-ncat python3-prettytable python3-jinja2 python3-PyYAML python3-argcomplete python3-packaging
+Requires:       python3 libvirt-python3 genisoimage nmap-ncat python3-prettytable python3-jinja2 python3-PyYAML python3-argcomplete python3-setuptools
 
 %description
 Kcli is a wrapper for local/remote libvirt, aws, azure, gcp, kubevirt, ovirt, openstack, packet, proxmox and vsphere

--- a/kvirt/jinjafilters/jinjafilters.py
+++ b/kvirt/jinjafilters/jinjafilters.py
@@ -2,7 +2,7 @@ from base64 import b64encode
 from glob import glob
 from ipaddress import ip_address, ip_network
 import os
-from distutils.version import LooseVersion
+from packaging.version import parse
 import json
 import sys
 from urllib.request import urlopen
@@ -73,7 +73,7 @@ def github_version(repo, version=None, tag_mode=False):
         data = json.loads(urlopen(f"https://api.github.com/repos/{repo}/{obj}", timeout=5).read())
         if 'message' in data and data['message'] == 'Not Found':
             return ''
-        tags = sorted([x[tag_name] for x in data if stable_release(x, tag_mode)], key=LooseVersion, reverse=True)
+        tags = sorted([x[tag_name] for x in data if stable_release(x, tag_mode)], key=parse, reverse=True)
         if tags:
             tag = tags[0]
         else:

--- a/kvirt/jinjafilters/jinjafilters.py
+++ b/kvirt/jinjafilters/jinjafilters.py
@@ -2,7 +2,7 @@ from base64 import b64encode
 from glob import glob
 from ipaddress import ip_address, ip_network
 import os
-from packaging.version import parse
+from pkg_resources import parse_version
 import json
 import sys
 from urllib.request import urlopen
@@ -73,7 +73,7 @@ def github_version(repo, version=None, tag_mode=False):
         data = json.loads(urlopen(f"https://api.github.com/repos/{repo}/{obj}", timeout=5).read())
         if 'message' in data and data['message'] == 'Not Found':
             return ''
-        tags = sorted([x[tag_name] for x in data if stable_release(x, tag_mode)], key=parse, reverse=True)
+        tags = sorted([x[tag_name] for x in data if stable_release(x, tag_mode)], key=parse_version, reverse=True)
         if tags:
             tag = tags[0]
         else:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 import os
-INSTALL = ['argcomplete', 'PyYAML', 'prettytable', 'jinja2', 'libvirt-python>=2.0.0']
+INSTALL = ['argcomplete', 'PyYAML', 'prettytable', 'jinja2', 'libvirt-python>=2.0.0', 'packaging']
 AWS = ['boto3']
 AZURE = ['azure-mgmt-compute', 'azure-mgmt-network', 'azure-mgmt-core', 'azure-identity', 'azure-mgmt-resource',
          'azure-mgmt-marketplaceordering', 'azure-storage-blob', 'azure-mgmt-dns', 'azure-mgmt-containerservice',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 import os
-INSTALL = ['argcomplete', 'PyYAML', 'prettytable', 'jinja2', 'libvirt-python>=2.0.0', 'packaging']
+INSTALL = ['argcomplete', 'PyYAML', 'prettytable', 'jinja2', 'libvirt-python>=2.0.0', 'setuptools']
 AWS = ['boto3']
 AZURE = ['azure-mgmt-compute', 'azure-mgmt-network', 'azure-mgmt-core', 'azure-identity', 'azure-mgmt-resource',
          'azure-mgmt-marketplaceordering', 'azure-storage-blob', 'azure-mgmt-dns', 'azure-mgmt-containerservice',


### PR DESCRIPTION
distutils is used in a single file, but the package has been removed in python 3.12.
https://docs.python.org/3.10/whatsnew/3.10.html#distutils-deprecated

As a result, running kcli under python 3.12 is not possible.

This PR replaces distutils.version.LooseVersion with packaging.version.parse which should be equivalent:
https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html
https://github.com/Azure/azure-cli/pull/17667/files

I believe I have added the pip package requirements in the necessary places, but please verify that.