### PR TITLE
Fix plan create `TypeError`

### DIFF
--- a/kvirt/cli.py
+++ b/kvirt/cli.py
@@ -2107,10 +2107,10 @@ def create_plan(args):
             config.delete_plan(plan, unregister=config.rhnunregister)
     result = config.plan(plan, ansible=ansible, url=url, path=path, container=container, inputfile=inputfile,
                          overrides=overrides, pre=pre, post=post, threaded=threaded)
-    if 'result' in result and result['result'] == 'success':
+    if result and result.get('result') == 'success':
         sys.exit(0)
     else:
-        if 'reason' in result:
+        if result and 'reason' in result:
             error(result['reason'])
         sys.exit(1)
 

--- a/kvirt/config.py
+++ b/kvirt/config.py
@@ -2263,7 +2263,7 @@ class Kconfig(Kbaseconfig):
         if ansibleentries and not onlyassets:
             if not newvms:
                 warning("Ansible skipped as no new vm within playbook provisioned")
-                return
+                return {'result': 'success'}
             for entry in sorted(ansibleentries):
                 _ansible = entries[entry]
                 if 'playbook' not in _ansible:


### PR DESCRIPTION
When we create a plan but the VMs already exist and ansible is skipped, then we end up with an ugly TypeError exception on the command line.

```
  File "/usr/lib/python3.12/site-packages/kvirt/cli.py", line 2110, in create_plan
    if 'result' in result and result['result'] == 'success':
       ^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```

This PR fixes this by treating `None` values of `result` as failures without a message, and also considers the plan skipping ansible because there are no new VMs as a success.

Fixes #638