### PR TITLE
Allow users to use aws/gcp spot instances for only workers or only ctlplanes

### DIFF
--- a/kvirt/providers/aws/__init__.py
+++ b/kvirt/providers/aws/__init__.py
@@ -373,7 +373,7 @@ class Kaws(object):
                     userdata += 'cloud-init clean --logs\nreboot'
         else:
             userdata = ''
-        if overrides.get('spot', False):
+        if (overrides.get('spot_ctlplanes', False) and 'ctlplane' in name) or (overrides.get('spot_workers', False) and 'worker' in name):
             userdata_encode = (b64encode(userdata.encode())).decode("utf-8")
             LaunchSpecification = {'SecurityGroups': SecurityGroupIds,
                                    'ImageId': imageid,

--- a/kvirt/providers/aws/__init__.py
+++ b/kvirt/providers/aws/__init__.py
@@ -373,7 +373,9 @@ class Kaws(object):
                     userdata += 'cloud-init clean --logs\nreboot'
         else:
             userdata = ''
-        if (overrides.get('spot_ctlplanes', False) and 'ctlplane' in name) or (overrides.get('spot_workers', False) and 'worker' in name):
+        if (overrides.get('spot', False) or 
+                (overrides.get('spot_ctlplanes', False) and 'ctlplane' in name) or 
+                (overrides.get('spot_workers', False) and 'worker' in name)):
             userdata_encode = (b64encode(userdata.encode())).decode("utf-8")
             LaunchSpecification = {'SecurityGroups': SecurityGroupIds,
                                    'ImageId': imageid,

--- a/kvirt/providers/gcp/__init__.py
+++ b/kvirt/providers/gcp/__init__.py
@@ -417,7 +417,9 @@ class Kgcp(object):
                                               'enableSecureBoot': secureboot}
         if 'confidential' in overrides and overrides['confidential']:
             body['confidentialInstanceConfig'] = {'enableConfidentialCompute': True}
-        if (overrides.get('spot_ctlplanes', False) and 'ctlplane' in name) or (overrides.get('spot_workers', False) and 'worker' in name):
+        if (overrides.get('spot', False) or
+                (overrides.get('spot_ctlplanes', False) and 'ctlplane' in name) or
+                (overrides.get('spot_workers', False) and 'worker' in name)):
             if 'scheduling' not in body:
                 body['scheduling'] = {}
             body['scheduling']['provisioningModel'] = 'SPOT'

--- a/kvirt/providers/gcp/__init__.py
+++ b/kvirt/providers/gcp/__init__.py
@@ -417,7 +417,7 @@ class Kgcp(object):
                                               'enableSecureBoot': secureboot}
         if 'confidential' in overrides and overrides['confidential']:
             body['confidentialInstanceConfig'] = {'enableConfidentialCompute': True}
-        if overrides.get('spot', False):
+        if (overrides.get('spot_ctlplanes', False) and 'ctlplane' in name) or (overrides.get('spot_workers', False) and 'worker' in name):
             if 'scheduling' not in body:
                 body['scheduling'] = {}
             body['scheduling']['provisioningModel'] = 'SPOT'


### PR DESCRIPTION
Hi @karmab, 

It would be useful to us in the Kubernemlig team if we could use spot instances for only our workers.
This should allow for that while keeping compatibility with the previous 'spot' configuration option.