### PR TITLE
Hypershift: fix ignition service name

### DIFF
--- a/kvirt/cluster/hypershift/ignition.sh
+++ b/kvirt/cluster/hypershift/ignition.sh
@@ -8,11 +8,11 @@ TOKEN=$(oc -n $NAMESPACE get secret $SECRET -o jsonpath='{.data.value}' | base64
 
 {% if nodeport|default(False) %}
 IP=$(oc get node -o wide --selector='node-role.kubernetes.io/master' | grep -v NAME|  head -1 | awk '{print $6}')
-PORT=$(oc -n $NAMESPACE get svc ignition-server -o jsonpath={.spec.ports[0].nodePort})
+PORT=$(oc -n $NAMESPACE get svc ignition-server-proxy -o jsonpath={.spec.ports[0].nodePort})
 curl -k -H "Authorization: $TOKEN" https://$IP:$PORT/ignition > $CLUSTERDIR/nodepool.ign
 {% else %}
 MANAGEMENT_INGRESS_DOMAIN={{ management_ingress_domain }}
-curl -k -H "Authorization: $TOKEN" https://ignition-server-$NAMESPACE.$MANAGEMENT_INGRESS_DOMAIN/ignition > $CLUSTERDIR/nodepool.ign
+curl -k -H "Authorization: $TOKEN" https://ignition-server-proxy-$NAMESPACE.$MANAGEMENT_INGRESS_DOMAIN/ignition > $CLUSTERDIR/nodepool.ign
 {% endif %}
 
 if [ ! -s $CLUSTERDIR/nodepool.ign ] || [ "$(grep 'Token not found' $CLUSTERDIR/nodepool.ign)" != "" ] || [ "$(grep '503 Service Unavailable' $CLUSTERDIR/nodepool.ign)" != "" ] ; then


### PR DESCRIPTION
Proposing a fix to reflect that the NodePort is exposed by the `ignition-server-proxy` service, not `ignition-server`.

I stumbled in this bug when running `kcli create cluster hypershift`.

Log before the fix:
```
$ cat kcli-hyper-params.yaml 
version: stable
tag: 4.13
ingress_ip: 192.168.122.252
workers: 2
sslip: true

$ kcli create cluster hypershift --pf kcli-hyper-params.yaml hyper-6                                                                                                                            
Deploying cluster hyper-6                                                                                                                                                                                          
Using default class slow                                                                                                                                                                                           
Hypershift not fully installed. Installing it for you                                                                                                                                                              
Error from server (AlreadyExists): error when creating "install.yml": namespaces "multicluster-engine" already exists                                                                                              
Error from server (AlreadyExists): error when creating "install.yml": operatorgroups.operators.coreos.com "multicluster-engine-operatorgroup" already exists                                                       
Error from server (AlreadyExists): error when creating "install.yml": subscriptions.operators.coreos.com "multicluster-engine" already exists                                                                      
Error from server (invalid TargetNamespace: MultiClusterEngine with targetNamespace already exists: 'multiclusterengine'): error when creating "cr.yml": admission webhook "multiclusterengines.multicluster.opensh
ift.io" denied the request: invalid TargetNamespace: MultiClusterEngine with targetNamespace already exists: 'multiclusterengine'                                                                                  
Couldn't figure out management ingress ip. Using node port instead                                                                                                                                                 
Using 192.168.122.253 as management api ip                                                                                                                                                                         
Using keepalived virtual_router_id 70                                                                                                                                                                              
Setting domain to 192-168-122-252.sslip.io                                                                                                                                                                         
Creating control plane assets                                                                                                                                                                                      
namespace/clusters created                                                                                                                                                                                         
secret/hyper-6-pull-secret created                                                                                                                                                                                 
secret/hyper-6-ssh-key created                                                                                                                                                                                     
hostedcluster.hypershift.openshift.io/hyper-6 created                                                                                                                                                              
Downloading openshift-install from https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.13                                                                                                           
Move downloaded openshift-install somewhere in your PATH if you want to reuse it                                                                                                                                   
Using installer version 4.13.34                                                                                                                                                                                    
Using image rhcos-413.92.202401100947-0-openstack.x86_64.qcow2                                                                                                                                                     
nodepool.hypershift.openshift.io/hyper-6 created                                                                                                                                                                   
Waiting before ignition data is available                                                                                                                                                                          
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current                                                                                                                                    
                                 Dload  Upload   Total   Spent    Left  Speed                                                                                                                                      
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (7) Failed to connect to 192.168.122.153 port 443: Connection refused
...
Timeout trying to retrieve worker ignition
```