### PR TITLE
Switch to use pkgs.k8s.io

### DIFF
--- a/kvirt/cluster/kubeadm/kubernetes.repo
+++ b/kvirt/cluster/kubeadm/kubernetes.repo
@@ -1,6 +1,6 @@
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/
 enabled=1
-gpgcheck=0
-repo_gpgcheck=0
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/repodata/repomd.xml.key

--- a/kvirt/cluster/kubeadm/pre_el.sh
+++ b/kvirt/cluster/kubeadm/pre_el.sh
@@ -1,9 +1,9 @@
 echo """[kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/
 enabled=1
-gpgcheck=0
-repo_gpgcheck=0""" >/etc/yum.repos.d/kubernetes.repo
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/repodata/repomd.xml.key""" >/etc/yum.repos.d/kubernetes.repo
 echo net.bridge.bridge-nf-call-iptables=1 >> /etc/sysctl.d/99-sysctl.conf
 modprobe br_netfilter
 sysctl -p

--- a/kvirt/cluster/kubeadm/pre_ubuntu.sh
+++ b/kvirt/cluster/kubeadm/pre_ubuntu.sh
@@ -1,7 +1,8 @@
 apt-get update && apt-get -y install apt-transport-https curl git
-curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+mkdir -p -m 755 /etc/apt/keyrings
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
-deb http://apt.kubernetes.io/ kubernetes-xenial main
+deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /
 EOF
 apt-get update
 {% if version != None %}


### PR DESCRIPTION
The old package repos are deprecated and seem to have been removed now (see https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/) , so switch to use the new versions

Fixes: #646