### PR TITLE
Format kubernetes package versions correctly

### DIFF
--- a/kvirt/cluster/kubeadm/pre_el.sh
+++ b/kvirt/cluster/kubeadm/pre_el.sh
@@ -1,4 +1,6 @@
-VERSION={{ version or "$(curl -L -s https://dl.k8s.io/release/stable.txt | cut -d. -f1,2)" }} 
+VERSION={{ version or "$(curl -L -s https://dl.k8s.io/release/stable.txt)" }}
+# Ensure the version is in the format v<major>.<minor> regardless of the source
+VERSION=$(echo "v${VERSION#v}" | cut -d. -f1,2)
 
 echo """[kubernetes]
 name=Kubernetes

--- a/kvirt/cluster/kubeadm/pre_ubuntu.sh
+++ b/kvirt/cluster/kubeadm/pre_ubuntu.sh
@@ -1,6 +1,8 @@
 apt-get update && apt-get -y install apt-transport-https curl git
 
-VERSION={{ version or "$(curl -L -s https://dl.k8s.io/release/stable.txt | cut -d. -f1,2)" }}
+VERSION={{ version or "$(curl -L -s https://dl.k8s.io/release/stable.txt)" }}
+# Ensure the version is in the format v<major>.<minor> regardless of the source
+VERSION=$(echo "v${VERSION#v}" | cut -d. -f1,2)
 mkdir -p -m 755 /etc/apt/keyrings
 curl -fsSL https://pkgs.k8s.io/core:/stable:/$VERSION/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 cat <<EOF >/etc/apt/sources.list.d/kubernetes.list


### PR DESCRIPTION
The kuberentes package versions have the format v<major>.<minor>, so we want to ensure that if a user specifies the version or we fall back to the latest Kuberentes version
we still have the correct format

Fixes: #648