### PR TITLE
Fixes problem rendering index image in 4.15

### DIFF
--- a/kvirt/cluster/openshift/disconnected/scripts/05_olm.sh
+++ b/kvirt/cluster/openshift/disconnected/scripts/05_olm.sh
@@ -25,7 +25,7 @@ podman login -u "$RHN_USER" -p "$RHN_PASSWORD" registry.redhat.io
 
 which oc-mirror >/dev/null 2>&1
 if [ "$?" != "0" ] ; then
-  curl -Ls https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.13.12/oc-mirror.tar.gz | tar xvz -C /usr/bin
+  curl -Ls https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.15.5/oc-mirror.tar.gz | tar xvz -C /usr/bin
   chmod +x /usr/bin/oc-mirror
 fi
 


### PR DESCRIPTION
This is the issue that fixes when rendering the catalog image:

```
Rendering catalog image "infra.5g-deployment.lab:8443/redhat/redhat-operator-index:v4.15-1711601986" with file-based catalog 
error: error rebuilding catalog images from file-based catalogs: error regenerating the cache for infra.5g-deployment.lab:8443/redhat/redhat-operator-index:v4.15-1711601986: exit status 1
Traceback (most recent call last):
  File "/usr/bin/kcli", line 11, in <module>
    load_entry_point('kcli==99.0', 'console_scripts', 'kcli')()
  File "/usr/lib/python3.6/site-packages/kvirt/cli.py", line 5481, in cli
    args.func(args)
  File "/usr/lib/python3.6/site-packages/kvirt/cli.py", line 1884, in create_openshift_kube
    create_kube(args)
  File "/usr/lib/python3.6/site-packages/kvirt/cli.py", line 1830, in create_kube
    result = config.create_kube(cluster, kubetype, overrides=overrides)
  File "/usr/lib/python3.6/site-packages/kvirt/config.py", line 2854, in create_kube
    result = self.create_kube_openshift(cluster, overrides=overrides)
  File "/usr/lib/python3.6/site-packages/kvirt/config.py", line 2940, in create_kube_openshift
    return openshift.create(self, plandir, cluster, overrides, dnsconfig=dnsconfig)
  File "/usr/lib/python3.6/site-packages/kvirt/cluster/openshift/__init__.py", line 1125, in create
    update_disconnected_registry(config, plandir, cluster, data)
  File "/usr/lib/python3.6/site-packages/kvirt/cluster/openshift/__init__.py", line 181, in update_disconnected_registry
    mapping_to_icsp(config, plandir, f"{clusterdir}", f"{clusterdir}/mirror-config.yaml")
  File "/usr/lib/python3.6/site-packages/kvirt/cluster/openshift/__init__.py", line 64, in mapping_to_icsp
    mapping_file = glob("oc-mirror-workspace/results-*/mapping.txt")[0]
```