### PR TITLE
Use correct SSH user when waiting for VM boot

### DIFF
--- a/kvirt/config.py
+++ b/kvirt/config.py
@@ -2608,7 +2608,7 @@ class Kconfig(Kbaseconfig):
         oldoutput = ''
         timeout = 0
         while True:
-            sshcmd = common.ssh(name, user='root', ip=ip, tunnel=config.tunnel, tunnelhost=config.tunnelhost,
+            sshcmd = common.ssh(name, user=user, ip=ip, tunnel=config.tunnel, tunnelhost=config.tunnelhost,
                                 vmport=vmport, tunnelport=config.tunnelport, tunneluser=config.tunneluser,
                                 insecure=config.insecure, cmd=cmd, identityfile=identityfile, password=False)
             output = os.popen(sshcmd).read()

--- a/kvirt/providers/kvm/__init__.py
+++ b/kvirt/providers/kvm/__init__.py
@@ -2259,6 +2259,14 @@ class Kvirt(object):
 
     def clone(self, old, new, full=False, start=False):
         conn = self.conn
+        print(new)
+        try:
+            conn.lookupByName(new)
+            msg = f"VM {new} already exists"
+            error(msg)
+            return {'result': 'failure', 'reason': msg}
+        except:
+            pass
         try:
             oldvm = conn.lookupByName(old)
         except:
@@ -2280,6 +2288,8 @@ class Kvirt(object):
         for disk in list(tree.iter('disk')):
             if firstdisk or full:
                 source = disk.find('source')
+                if source is None:
+                    continue
                 oldpath = source.get('file')
                 oldvolume = self.conn.storageVolLookupByPath(oldpath)
                 pool = oldvolume.storagePoolLookupByVolume()


### PR DESCRIPTION
A few lines above this change an SSH connection is being established to test the gathered IP. This uses a previously determined user name.

The SSH connection to check whether the VM boot finished then used the hard-coded root user. A VM can be configured with a different user where SSH connections to the root user aren't possible. For such VMs the setup process is stuck at this step, repeatedly failing to connect via SSH.

This is fixed by using the declared `user` variable which is set and already used by the code above.

The `user` variable could be `None` in case the previous loop exits due to the wait timeout being reached. In this case the `ip` would also be `None` so this change doesn't introduce an additional failure case.