### PR TITLE
Redifh root route should not use credentials

### DIFF
--- a/kvirt/ksushy/__init__.py
+++ b/kvirt/ksushy/__init__.py
@@ -68,7 +68,6 @@ class Ksushy():
 
         @app.route('/redfish/v1')
         @app.route('/redfish/v1/')
-        @auth_basic(credentials)
         @view('root.json')
         def root_resource():
             return {}


### PR DESCRIPTION
In sushy-tools the root route `/redfish/v1` dont
use credentials:

```
 curl https://10.6.77.20:6443/redfish/v1/  -k
{
    "@odata.type": "#ServiceRoot.v1_0_2.ServiceRoot",
    "Id": "RedvirtService",
    "Name": "Redvirt Service",
    "RedfishVersion": "1.0.2",
    "UUID": "85775665-c110-4b85-8989-e6162170b3ec",
    "Systems": {
        "@odata.id": "/redfish/v1/Systems"
    },
    "Managers": {
        "@odata.id": "/redfish/v1/Managers"
    },
    "Registries": {
        "@odata.id": "/redfish/v1/Registries"
    },
    "@odata.id": "/redfish/v1/",
    "@Redfish.Copyright": "Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
}
```

The same request on ksushy expects credentials:

```
> curl https://10.6.77.20:9000/redfish/v1/  -k

    <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
    <html>
        <head>
            <title>Error: 401 Unauthorized</title>
            <style type="text/css">
              html {background-color: #eee; font-family: sans-serif;}
              body {background-color: #fff; border: 1px solid #ddd;
                    padding: 15px; margin: 15px;}
              pre {background-color: #eee; border: 1px solid #ddd; padding: 5px;}
            </style>
        </head>
        <body>
            <h1>Error: 401 Unauthorized</h1>
            <p>Sorry, the requested URL <tt>&#039;https://10.6.77.20:9000/redfish/v1/&#039;</tt>
               caused an error:</p>
            <pre>Access denied</pre>
        </body>
    </html>

```

This is also expected by ironic. One of its first
steps, it checks the redfish interface and it does not use credentials.

```
2024-05-08 14:59:21.278 1 WARNING ironic.drivers.modules.redfish.utils [None req-3fd531cc-782c-445b-a2f1-55a765f4e779 - - - - - -] For node 2333f867-1c5e-469e-a225-eefcaf438b23, we received an authentication access error from address https://10.6.77.20:9000 with auth_type auto. The client will not be re-used upon the next re-attempt. Please ensure your using the correct credentials. Error: HTTP GET https://10.6.77.20:9000/redfish/v1/ returned code 401. unknown error Extended information: None: sushy.exceptions.AccessError: HTTP GET https://10.6.77.20:9000/redfish/v1/ returned code 401. unknown error Extended information: None

```

