### PR TITLE
Upload only ssh keys specified in keys array if any specified

### DIFF
--- a/kvirt/common/__init__.py
+++ b/kvirt/common/__init__.py
@@ -1050,10 +1050,6 @@ def ignition(name, keys=[], cmds=[], nets=[], gateway=None, dns=None, domain=Non
     else:
         localhostname = name
     if not nokeys:
-        publickeyfile = get_ssh_pub_key()
-        if publickeyfile is not None:
-            with open(publickeyfile, 'r') as ssh:
-                publickeys.append(ssh.read().strip())
         if keys:
             for key in list(set(keys)):
                 newkey = key
@@ -1065,7 +1061,12 @@ def ignition(name, keys=[], cmds=[], nets=[], gateway=None, dns=None, domain=Non
                     continue
                 if newkey not in publickeys:
                     publickeys.append(newkey)
-        elif not publickeys and which('ssh-add') is not None:
+        else:
+            publickeyfile = get_ssh_pub_key()
+            if publickeyfile is not None:
+                with open(publickeyfile, 'r') as ssh:
+                    publickeys.append(ssh.read().strip())
+        if not publickeys and which('ssh-add') is not None:
             agent_keys = os.popen('ssh-add -L 2>/dev/null | head -1').readlines()
             if agent_keys:
                 publickeys = agent_keys


### PR DESCRIPTION
Hi @karmab 

I think it would be more clear if only the public keys specified in the keys array in the plan file are uploaded to the VM's. It's possible the plan file will also need a way to specify a way to reach the corresponding private keys for the later ssh/scp attempts.

Currently it is a bit of a confusing side effect that a ssh key that you happen to have lying around on your disk will also end up on the VM.

This PR so far only prevents the upload of the additional key if any keys were specified explicitly in the plan file.