### PR TITLE
Fail if all three iso tools are missing

### DIFF
--- a/kvirt/common/__init__.py
+++ b/kvirt/common/__init__.py
@@ -1899,7 +1899,7 @@ def make_iso(name, tmpdir, userdata, metadata, netdata, openstack=False, combust
         x.write(userdata)
     with open(f"{tmpdir}/meta-data", 'w') as y:
         y.write(metadata)
-    if which('mkisofs') is None and which('genisoimage') and which('xorrisofs') is None:
+    if which('mkisofs') is None and which('genisoimage') is None and which('xorrisofs') is None:
         error("mkisofs, genisoimage or xorrisofs are required in order to create cloudinit iso")
         sys.exit(1)
     isocmd = 'genisoimage' if which('genisoimage') is not None else 'mkisofs' if which('mkisofs') is not None\


### PR DESCRIPTION
There was a bug where the error would only be thrown if genisoimage was available while mkisofs and xorrisofs were missing.