### PR TITLE
Add create_hostname_file parameter to cloud-init

### DIFF
--- a/kvirt/common/__init__.py
+++ b/kvirt/common/__init__.py
@@ -300,6 +300,7 @@ def cloudinit(name, keys=[], cmds=[], nets=[], gateway=None, dns=None, domain=No
         userdata += 'final_message: kcli boot finished, up $UPTIME seconds\n'
         if not noname:
             userdata += f'hostname: {name}\n'
+            userdata += f'create_hostname_file: true\n'
             if fqdn:
                 fqdn = f"{name}.{domain}" if domain is not None else name
                 userdata += f"fqdn: {fqdn}\n"


### PR DESCRIPTION
GCE has decided that create_hostname_file should be false by default for newer ubuntu images. Therefore it should be set explicitly.

See https://documentation.ubuntu.com/gcp/en/latest/_sources/google-how-to/gce/set-hostname-using-cloudinit.rst.txt for an explanation on googles change.

See the config schema at https://docs.cloud-init.io/en/latest/reference/modules.html#set-hostname for proof that the default value of create_hostname_file is true.