### PR TITLE
Add boot_disk_type, worker_disk_type, and ctlplane disk_type settings

### DIFF
--- a/kvirt/cluster/k3s/ctlplanes.yml
+++ b/kvirt/cluster/k3s/ctlplanes.yml
@@ -6,6 +6,9 @@
 {% if extra_ctlplane_disks %}
  {% set extra_disks = extra_ctlplane_disks %}
 {% endif %}
+{% if ctlplane_disk_type %}
+ {% set disk_type = ctlplane_disk_type %}
+{% endif %}
 
 {% set all_files = files|default([]) %}
 {% set all_scripts = ["ctlplanes.sh"] %}
@@ -28,6 +31,9 @@
  loadbalancer: api.{{ cluster }}
 {% endif %}
  disks: {{ [disk_size] + extra_disks }}
+{% if disk_type|default(False) %}
+ disk_type: {{disk_type}}
+{% endif %}
  files: {{ all_files }}
  scripts: {{ all_scripts }}
 {% endfor %}

--- a/kvirt/cluster/k3s/kcli_default.yml
+++ b/kvirt/cluster/k3s/kcli_default.yml
@@ -28,6 +28,9 @@ kubevirt_disk_size:
 extra_disks: []
 extra_ctlplane_disks: []
 extra_worker_disks: []
+boot_disk_type:
+ctlplane_disk_type:
+worker_disk_type:
 extra_networks: []
 extra_ctlplane_networks: []
 extra_worker_networks: []

--- a/kvirt/cluster/k3s/workers.yml
+++ b/kvirt/cluster/k3s/workers.yml
@@ -5,6 +5,9 @@
 {% if extra_worker_disks %}
  {% set extra_disks = extra_worker_disks %}
 {% endif %}
+{% if worker_disk_type %}
+ {% set disk_type = worker_disk_type %}
+{% endif %}
 
 {% set default_worker = cluster + '-worker-' + number|string %}
 {% set worker = vmrules_names[number] if vmrules_names is defined else default_worker %}
@@ -17,6 +20,9 @@
  memory: {{ worker_memory | default(memory, memory) }}
  nets: {{ [network] + extra_networks }}
  disks: {{ [disk_size] + extra_disks }}
+{% if disk_type|default(False) %}
+ disk_type: {{disk_type}}
+{% endif %}
  files:
  - join.sh
  scripts:

--- a/kvirt/cluster/kubeadm/ctlplanes.yml
+++ b/kvirt/cluster/kubeadm/ctlplanes.yml
@@ -6,6 +6,9 @@
 {% if extra_ctlplane_disks %}
  {% set extra_disks = extra_ctlplane_disks %}
 {% endif %}
+{% if ctlplane_disk_type %}
+ {% set disk_type = ctlplane_disk_type %}
+{% endif %}
 
 {{ cluster }}-ctlplane-{{ number }}:
 {% set primary_network = {'name': network} %}
@@ -20,6 +23,9 @@
 {% endif %}
  nets: {{ [primary_network] + extra_networks }}
  disks: {{ [disk_size] + extra_disks }}
+{% if disk_type|default(False) %}
+ disk_type: {{disk_type}}
+{% endif %}
  files:
 {% if config_type not in ['aws', 'gcp', 'ibm'] %}
  - keepalived.conf

--- a/kvirt/cluster/kubeadm/kcli_default.yml
+++ b/kvirt/cluster/kubeadm/kcli_default.yml
@@ -49,6 +49,9 @@ kubevirt_disk_size:
 extra_disks: []
 extra_ctlplane_disks: []
 extra_worker_disks: []
+boot_disk_type:
+ctlplane_disk_type:
+worker_disk_type:
 extra_networks: []
 extra_ctlplane_networks: []
 extra_worker_networks: []

--- a/kvirt/cluster/kubeadm/workers.yml
+++ b/kvirt/cluster/kubeadm/workers.yml
@@ -5,6 +5,9 @@
 {% if extra_worker_disks %}
  {% set extra_disks = extra_worker_disks %}
 {% endif %}
+{% if worker_disk_type %}
+ {% set disk_type = worker_disk_type %}
+{% endif %}
 
 {{cluster }}-worker-{{ number }}:
  image: {{ image }}
@@ -16,6 +19,9 @@
  domain: {{ domain }}
  nets: {{ [network] + extra_networks }}
  disks: {{ [disk_size] + extra_disks }}
+{% if disk_type|default(False) %}
+ disk_type: {{disk_type}}
+{% endif %}
  files:
  - path: /root/pre.sh
    origin: pre_{{ 'ubuntu' if ubuntu|default(False) else 'el' }}.sh

--- a/kvirt/cluster/openshift/ctlplanes.yml
+++ b/kvirt/cluster/openshift/ctlplanes.yml
@@ -5,6 +5,9 @@
 {% if extra_ctlplane_disks %}
 {% set extra_disks = extra_ctlplane_disks %}
 {% endif %}
+{% if ctlplane_disk_type %}
+ {% set disk_type = ctlplane_disk_type %}
+{% endif %}
 {% if flavor_ctlplane != None %}
 {% set flavor = flavor_ctlplane %}
 {% endif %}
@@ -28,6 +31,9 @@
 {% endif %}
  nets: {{ [network] + extra_networks }}
  disks: {{ [disk_size] + extra_disks }}
+{% if disk_type|default(False) %}
+ disk_type: {{disk_type}}
+{% endif %}
  files:
 {% if coredns %}
   - path: /etc/NetworkManager/dispatcher.d/99-forcedns

--- a/kvirt/cluster/openshift/kcli_default.yml
+++ b/kvirt/cluster/openshift/kcli_default.yml
@@ -66,6 +66,9 @@ kubevirt_ignore_node_port: false
 extra_disks: []
 extra_ctlplane_disks: []
 extra_worker_disks: []
+boot_disk_type:
+ctlplane_disk_type:
+worker_disk_type:
 extra_networks: []
 extra_ctlplane_networks: []
 extra_worker_networks: []

--- a/kvirt/cluster/openshift/workers.yml
+++ b/kvirt/cluster/openshift/workers.yml
@@ -10,6 +10,9 @@
 {% if extra_worker_disks %}
 {% set extra_disks = extra_worker_disks %}
 {% endif %}
+{% if worker_disk_type %}
+ {% set disk_type = worker_disk_type %}
+{% endif %}
 {% if flavor_worker != None %}
 {% set flavor = flavor_worker %}
 {% endif %}
@@ -33,6 +36,9 @@
 {% endif %}
  nets: {{ [network] + extra_networks }}
  disks: {{ [disk_size] + extra_disks }}
+{% if disk_type|default(False) %}
+ disk_type: {{disk_type}}
+{% endif %}
  files:
 {% if coredns %}
   - path: /etc/NetworkManager/dispatcher.d/99-forcedns

--- a/kvirt/providers/gcp/__init__.py
+++ b/kvirt/providers/gcp/__init__.py
@@ -276,11 +276,17 @@ class Kgcp(object):
                     disksize = 20
                     pprint("Rounding primary disk to to 20Gb")
                 newdisk['initializeParams'] = {'sourceImage': src, 'diskSizeGb': disksize}
+                boot_disk_type = overrides.get('boot_disk_type', None)
+                if boot_disk_type:
+                    newdisk['initializeParams']['diskType'] = f'/compute/v1/projects/{project}/zones/{zone}/diskTypes/{boot_disk_type}'
                 newdisk['boot'] = True
             else:
                 diskname = f"{name}-disk{index}"
                 diskpath = f'/compute/v1/projects/{project}/zones/{zone}/disks/{diskname}'
                 info = {'name': diskname, 'sizeGb': disksize}
+                disk_type = overrides.get('disk_type', None)
+                if disk_type:
+                    info["type"] = f'/compute/v1/projects/{project}/zones/{zone}/diskTypes/{disk_type}'
                 conn.disks().insert(zone=zone, project=project, body=info).execute()
                 timeout = 0
                 while True:


### PR DESCRIPTION
Only adds support for GCP so far, but I hope the settings are general enough that they will work for other providers

See https://cloud.google.com/compute/docs/disks#disk-types for examples of disk types