### PR TITLE
Add retry to k3s join.sh curl

### DIFF
--- a/kvirt/cluster/k3s/join.sh
+++ b/kvirt/cluster/k3s/join.sh
@@ -4,4 +4,4 @@
 {% set api_ip = '{0}-ctlplane-1'.format(cluster)|kcli_info('ip') if scale|default(False) and 'ctlplane-0' in name else first_ip %}
 {% endif %}
 
-curl -sfL https://get.k3s.io | K3S_URL=https://{{ api_ip }}:6443 K3S_TOKEN={{ token }} {{ install_k3s_args|default([])|join(' ') }} sh -s - agent {{ extra_args|join(' ') }}
+curl --retry 5 -sfL https://get.k3s.io | K3S_URL=https://{{ api_ip }}:6443 K3S_TOKEN={{ token }} {{ install_k3s_args|default([])|join(' ') }} sh -s - agent {{ extra_args|join(' ') }}


### PR DESCRIPTION
I experienced an issue where join.sh would fail to execute on GCP, most probably because the curl statement was failing.

Unfortunately this is very hard for me to reproduce, but my thinking is that a little retry here can't hurt.