### PR TITLE
Add auth_type setting to keepalived conf

### DIFF
--- a/kvirt/cluster/hypershift/keepalived.conf
+++ b/kvirt/cluster/hypershift/keepalived.conf
@@ -13,8 +13,8 @@ vrrp_instance {{ cluster }}.{{ domain }}_INGRESS {
     priority 101
     advert_int 1
     authentication {
-        auth_type PASS
-        auth_pass 1111
+        auth_type {{ auth_type or PASS }}
+        auth_pass {{ auth_pass | default(1111) }}
     }
     virtual_ipaddress {
         {{ ingress_ip }}

--- a/kvirt/cluster/k3s/keepalived.conf
+++ b/kvirt/cluster/k3s/keepalived.conf
@@ -11,7 +11,7 @@ vrrp_instance {{ cluster }}.{{ domain }}_API {
     priority 101
     advert_int 1
     authentication {
-        auth_type PASS
+        auth_type {{ auth_type or PASS }}
         auth_pass {{ auth_pass | default(1111) }}
     }
     virtual_ipaddress {

--- a/kvirt/cluster/kubeadm/keepalived.conf
+++ b/kvirt/cluster/kubeadm/keepalived.conf
@@ -11,7 +11,7 @@ vrrp_instance {{ cluster }}.{{ domain }}_API {
     priority {{ '102' if name.endswith('-0') else '101' }}
     advert_int 1
     authentication {
-        auth_type PASS
+        auth_type {{ auth_type or PASS }}
         auth_pass {{ auth_pass | default(1111) }}
     }
     virtual_ipaddress {

--- a/kvirt/cluster/openshift/keepalived.conf
+++ b/kvirt/cluster/openshift/keepalived.conf
@@ -13,7 +13,7 @@ vrrp_instance {{ cluster }}.{{ domain }}_API {
     priority 101
     advert_int 1
     authentication {
-        auth_type PASS
+        auth_type {{ auth_type or PASS }}
         auth_pass {{ auth_pass | default(1111) }}
     }
     virtual_ipaddress {
@@ -32,7 +32,7 @@ vrrp_instance {{ cluster }}.{{ domain }}_INGRESS {
     priority 101
     advert_int 1
     authentication {
-        auth_type PASS
+        auth_type {{ auth_type or PASS }}
         auth_pass {{ auth_pass | default(1111) }}
     }
     virtual_ipaddress {
@@ -52,7 +52,7 @@ vrrp_instance {{ cluster }}.{{ domain }}_DUAL_API {
     priority 101
     advert_int 1
     authentication {
-        auth_type PASS
+        auth_type {{ auth_type or PASS }}
         auth_pass {{ auth_pass | default(1111) }}
     }
     virtual_ipaddress {
@@ -72,7 +72,7 @@ vrrp_instance {{ cluster }}.{{ domain }}_DUAL_INGRESS {
     priority 101
     advert_int 1
     authentication {
-        auth_type PASS
+        auth_type {{ auth_type or PASS }}
         auth_pass {{ auth_pass | default(1111) }}
     }
     virtual_ipaddress {


### PR DESCRIPTION
Add auth_type templating to keepalived.conf files. Also fixes an auth_pass that was no using the templating variable.

Using the auth_type variable, it should now be possible to specifiy auth_type: AH in kcli plan files, which is a more secure way for keepalived to authenticate with peers.
See https://louwrentius.com/configuring-attacking-and-securing-vrrp-on-linux.html for details on why this matters