### PR TITLE
add kcli ssh -t pseudo-terminal allocation

### DIFF
--- a/kvirt/cli.py
+++ b/kvirt/cli.py
@@ -2784,6 +2784,7 @@ def ssh_vm(args):
     D = args.D
     X = args.X
     Y = args.Y
+    force_pty = args.t
     identityfile = args.identityfile
     user = args.user
     vmport = args.port
@@ -2831,7 +2832,7 @@ def ssh_vm(args):
         sshcommand = common.ssh(name, ip=ip, user=user, local=local, remote=remote, tunnel=tunnel,
                                 tunnelhost=tunnelhost, tunnelport=tunnelport, tunneluser=tunneluser,
                                 insecure=insecure, cmd=cmd, X=X, Y=Y, D=D, debug=args.debug, vmport=vmport,
-                                identityfile=identityfile)
+                                identityfile=identityfile, force_pty=force_pty)
     if sshcommand is not None:
         if which('ssh') is not None:
             code = os.WEXITSTATUS(os.system(sshcommand))
@@ -5249,6 +5250,7 @@ def cli():
     vmssh_parser.add_argument('-Y', action='store_true', help='Enable X11 Forwarding(Insecure)')
     vmssh_parser.add_argument('-i', '--identityfile', help='Identity file')
     vmssh_parser.add_argument('-p', '--port', '--port', help='Port for ssh')
+    vmssh_parser.add_argument('-t', action='store_true', help='Force pseudo-terminal allocation')
     vmssh_parser.add_argument('-u', '-l', '--user', help='User for ssh')
     vmssh_parser.add_argument('name', metavar='VMNAME', nargs='*')
     vmssh_parser.set_defaults(func=ssh_vm)

--- a/kvirt/common/__init__.py
+++ b/kvirt/common/__init__.py
@@ -913,7 +913,7 @@ def print_info(yamlinfo, output='plain', fields=[], values=False, pretty=True):
 
 def ssh(name, ip='', user=None, local=None, remote=None, tunnel=False, tunnelhost=None, tunnelport=22,
         tunneluser='root', insecure=False, cmd=None, X=False, Y=False, debug=False, D=None, vmport=None,
-        identityfile=None, password=True):
+        identityfile=None, password=True, force_pty=False):
     if ip == '':
         return None
     else:
@@ -932,6 +932,8 @@ def ssh(name, ip='', user=None, local=None, remote=None, tunnel=False, tunnelhos
             sshcommand = f"-X {sshcommand}"
         if Y:
             sshcommand = f"-Y {sshcommand}"
+        if force_pty:
+            sshcommand = f"-t {sshcommand}"
         if cmd:
             sshcommand = f'{sshcommand} "{cmd}"'
         if tunnelhost is not None and tunnelhost not in ['localhost', '127.0.0.1'] and tunnel and\


### PR DESCRIPTION
When ssh(1) is invoked with a command it does not enable pty allocation. The `ssh -t` option forces pty allocation and is typically used together with commands that assume there is a terminal (for tab completion, job control in shells, etc).

Add the `kcli ssh -t` option so that commands can be invoked with a pseudo-terminal.