### PR TITLE
kvm aarch64: fix distro image url

### DIFF
--- a/kvirt/config.py
+++ b/kvirt/config.py
@@ -2399,7 +2399,10 @@ class Kconfig(Kbaseconfig):
             pprint(f"Using pool {pool}")
         if image is not None:
             if url is None:
-                if arch != 'x86_64':
+                if arch == 'aarch64':
+                    IMAGES.update({i: IMAGES[i].replace('x86_64', arch).replace('amd64', 'arm64')
+                                   for i in IMAGES})
+                elif arch != 'x86_64':
                     IMAGES.update({i: IMAGES[i].replace('x86_64', arch).replace('amd64', arch)
                                    for i in IMAGES})
                 if image not in IMAGES:

--- a/kvirt/providers/kvm/__init__.py
+++ b/kvirt/providers/kvm/__init__.py
@@ -845,7 +845,6 @@ class Kvirt(object):
                 cloudinitiso = f"{default_poolpath}/{name}.ISO"
                 dtype = 'block' if diskpath.startswith('/dev') else 'file'
                 dsource = 'dev' if diskpath.startswith('/dev') else 'file'
-                isobus = 'scsi' if aarch64_full else 'sata'
                 isobus = 'scsi' if (aarch64_full or as390x) else 'sata'
                 bootdevxml = f'<boot order="{bootdev_iso}"/>' if boot_order else ''
                 isoxml = """<disk type='%s' device='cdrom'>


### PR DESCRIPTION
Fix the distro url for aarch64 and remove redundant scsi setting.

```
$ kcli version
version: 99.0 commit: 0764076 2024/09/12 Available Updates: N/A
$ kcli download image ubuntu2204 -P arch=aarch64
Grabbing image ubuntu2204 from url https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-aarch64.img
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0   286    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
Image ubuntu2204 not Added because Unable to download indicated image
```

After fixed the distro url:
```
$ kcli download image ubuntu2204 -P arch=aarch64
Grabbing image ubuntu2204 from url https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  596M  100  596M    0     0  57.4M      0  0:00:10  0:00:10 --:--:-- 56.4M
Image ubuntu2204 Added
```

This is to enable kcli on aarch64/arm64 bare-metal server with [kcli_cluster.sh](https://github.com/confidential-containers/cloud-api-adaptor/blob/main/src/cloud-api-adaptor/libvirt/kcli_cluster.sh).

Some changes are already done in latest kcli to support aarch64:
- 7cad52ce: won't override the machine type from user's input for aarch64
- 342d5b80: always emulating virtio-scsi instead of a obsolete LSI adaptor

Add more comments below as not much info can be found in the above 2 commit messages:

Emulating a SATA device for cloud-init's ROM device is able to work for aarch64, but needs to change NIC name from `enp1s` to `enp3s`. Because the emulated SATA would introduce an extra PCI bridge and SATA AHCI controller, and the PCI bus id enumeration for the virtio-net NIC will be `0x3`. Due to the [deterministic network naming](https://wiki.debian.org/NetworkInterfaceNames), the NIC name in `cloud-init's network-config` needs to follow PCI bus id as `enp3s`.

1. SCSI cloud-init ROM device with virtio-scsi (now):
```
00:01.6 PCI bridge: Red Hat, Inc. QEMU PCIe Root port
01:00.0 Ethernet controller: Red Hat, Inc. Virtio network device (rev 01)
02:00.0 SCSI storage controller: Red Hat, Inc. Virtio SCSI (rev 01)
```
2. SATA cloud-init ROM device with AHCI controller (needs to change NIC name to `enp3s` in `cloudinit`):
```
00:01.6 PCI bridge: Red Hat, Inc. QEMU PCIe Root port
01:00.0 PCI bridge: Red Hat, Inc. Device 000e
02:01.0 SATA controller: Intel Corporation 82801IR/IO/IH (ICH9R/DO/DH) 6 port SATA Controller [AHCI mode] (rev 02)
03:00.0 Ethernet controller: Red Hat, Inc. Virtio network device (rev 01)
```
3. SCSI cloud-init ROM device with old LSI controller (without 342d5b80, modern distro has no driver):
```
00:01.6 PCI bridge: Red Hat, Inc. QEMU PCIe Root port
01:00.0 PCI bridge: Red Hat, Inc. Device 000e
02:01.0 SCSI storage controller: Broadcom / LSI 53c895a
03:00.0 Ethernet controller: Red Hat, Inc. Virtio network device (rev 01)
```