### PR TITLE
Fix Calico default version for kcli create kube generic

### DIFF
--- a/kvirt/cluster/kubeadm/kcli_default.yml
+++ b/kvirt/cluster/kubeadm/kcli_default.yml
@@ -60,7 +60,7 @@ ctlplanes_threaded: false
 workers_threaded: false
 keys: []
 tempkey: false
-calico_version: None
+calico_version:
 autoscale: False
 token:
 async: false


### PR DESCRIPTION
Fix Calico default version for kcli create kube generic

Closes: https://github.com/karmab/kcli/issues/732