### PR TITLE
fix #742 - return empty string, if no cidr value can be obtained

### DIFF
--- a/kvirt/providers/proxmox/__init__.py
+++ b/kvirt/providers/proxmox/__init__.py
@@ -771,7 +771,7 @@ class Kproxmox(Kbase):
                     if "active" in net and net["active"]:
                         netname = f"{n['node']}/{net['iface']}"
                         nets[netname] = {
-                            "cidr": net["cidr"],
+                            "cidr": net.get("cidr", ""),
                             "dhcp": True,
                             "type": "bridged",
                             "mode": "N/A",


### PR DESCRIPTION
This fix will return an empty string