### PR TITLE
small MR to make kcli successfully use a non-quay registry for disconnected.

### DIFF
--- a/kvirt/cluster/openshift/__init__.py
+++ b/kvirt/cluster/openshift/__init__.py
@@ -140,8 +140,8 @@ def update_disconnected_registry(config, plandir, cluster, data):
          shell=True)
     pprint("Updating disconnected registry")
     synccmd = f"oc adm release mirror -a {pull_secret_path} --from={get_release_image()} "
-    synccmd += f"--to-release-image={disconnected_url}/openshift/release-images:{tag}-{arch} "
-    synccmd += f"--to={disconnected_url}/openshift/release"
+    synccmd += f"--to-release-image={disconnected_url}/openshift-release-dev/ocp-release:{tag}-{arch} "
+    synccmd += f"--to={disconnected_url}/openshift-release-dev/ocp-release"
     pprint(f"Running {synccmd}")
     call(synccmd, shell=True)
     extra_releases = data.get('disconnected_extra_releases', [])
@@ -150,8 +150,8 @@ def update_disconnected_registry(config, plandir, cluster, data):
         for extra_release in extra_releases:
             tag_and_arch = re.search(r":(.+)$", extra_release).group(1)
             synccmd = f"oc adm release mirror -a {pull_secret_path} --from={extra_release} "
-            synccmd += f"--to-release-image={disconnected_url}/openshift/release-images:{tag_and_arch} "
-            synccmd += f"--to={disconnected_url}/openshift/release"
+            synccmd += f"--to-release-image={disconnected_url}/openshift-release-dev/ocp-release:{tag_and_arch} "
+            synccmd += f"--to={disconnected_url}/openshift-release-dev/ocp-release"
             pprint(f"Running {synccmd}")
             call(synccmd, shell=True)
     if which('oc-mirror') is None:
@@ -1009,7 +1009,7 @@ def create(config, plandir, cluster, overrides, dnsconfig=None):
         update_pull_secret(pull_secret, disconnected_url, disconnected_user, disconnected_password)
         data['ori_tag'] = tag
         if '/' not in str(tag):
-            tag = f'{disconnected_url}/openshift/release-images:{tag}-{arch}'
+            tag = f'{disconnected_url}/openshift-release-dev/ocp-release:{tag}-{arch}'
             os.environ['OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE'] = tag
         pprint(f"Setting OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE to {tag}")
         data['openshift_release_image'] = tag

--- a/kvirt/cluster/openshift/install-config.yaml
+++ b/kvirt/cluster/openshift/install-config.yaml
@@ -156,6 +156,7 @@ imageContentSources:
 - mirrors:
   - {{ disconnected_url }}/openshift-release-dev/ocp-v4.0-art-dev
   - {{ disconnected_url }}/openshift/release
+  - {{ disconnected_url }}/openshift/release-images
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 - mirrors:
   - {{ disconnected_url }}/ocp-release

--- a/kvirt/cluster/openshift/install-config.yaml
+++ b/kvirt/cluster/openshift/install-config.yaml
@@ -145,17 +145,21 @@ imageContentSources:
 - mirrors:
   - {{ disconnected_url }}/openshift/release
   - {{ disconnected_url }}/openshift/release-images
+  - {{ disconnected_url }}/openshift-release-dev/ocp-release
   source: registry.build01.ci.openshift.org/{{ release }}/release
 - mirrors:
   - {{ disconnected_url }}/openshift/release
   - {{ disconnected_url }}/openshift/release-images
+  - {{ disconnected_url }}/openshift-release-dev/ocp-release
   source: registry.build01.ci.openshift.org/{{ release }}/stable
 {% else %}
 - mirrors:
+  - {{ disconnected_url }}/openshift-release-dev/ocp-v4.0-art-dev
   - {{ disconnected_url }}/openshift/release
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 - mirrors:
-  - {{ disconnected_url }}/openshift/release-images
+  - {{ disconnected_url }}/ocp-release
+  - {{ disconnected_url }}/openshift-release-dev/ocp-release
 {% if ':' in tag|string %}
   source: {{ openshift_release_image.split('/')[0] }}/{{ (tag|string).split(':')[0] }}
 {% elif 'registry.ci' in openshift_release_image %}


### PR DESCRIPTION
Verified using Nexus 3.75.1 and that patch.