### PR TITLE
Hcloud disable placement group for workers

### DIFF
--- a/kvirt/providers/hcloud/__init__.py
+++ b/kvirt/providers/hcloud/__init__.py
@@ -107,8 +107,8 @@ class Khcloud():
                 if response.action:
                     response.action.wait_until_finished(300)
 
-                if response.action.error:
-                    return {'result': 'failure', 'reason': json.dumps(response.error)}
+                    if response.action.error:
+                        return {'result': 'failure', 'reason': json.dumps(response.error)}
 
             placement_group = response.placement_group
 

--- a/kvirt/providers/hcloud/__init__.py
+++ b/kvirt/providers/hcloud/__init__.py
@@ -96,14 +96,16 @@ class Khcloud():
             value = metadata[entry].replace('.', '-')
             labels[entry] = value
 
-        placement_group_name = f"kcli-{labels['plan']}"
-        placement_group = self.conn.placement_groups.get_by_name(placement_group_name)
-        if not placement_group:
-            response = self.conn.placement_groups.create(name=placement_group_name, type="spread",
-                                                         labels={"kcli-managed": "placement-group",
-                                                                 "plan": labels["plan"]})
-            if response.action:
-                response.action.wait_until_finished(300)
+        placement_group = None
+        if "worker" not in name:
+            placement_group_name = f"kcli-{labels['plan']}"
+            placement_group = self.conn.placement_groups.get_by_name(placement_group_name)
+            if not placement_group:
+                response = self.conn.placement_groups.create(name=placement_group_name, type="spread",
+                                                            labels={"kcli-managed": "placement-group",
+                                                                    "plan": labels["plan"]})
+                if response.action:
+                    response.action.wait_until_finished(300)
 
                 if response.action.error:
                     return {'result': 'failure', 'reason': json.dumps(response.error)}

--- a/kvirt/providers/hcloud/__init__.py
+++ b/kvirt/providers/hcloud/__init__.py
@@ -110,7 +110,7 @@ class Khcloud():
                     if response.action.error:
                         return {'result': 'failure', 'reason': json.dumps(response.error)}
 
-            placement_group = response.placement_group
+                placement_group = response.placement_group
 
         flavor_options = overrides.get("flavor_options", [flavor] if flavor is not None else [])
 


### PR DESCRIPTION
Hcloud/Hetzner allows a maximum of 10 servers in their [placement groups](https://docs.hetzner.com/cloud/placement-groups/overview).

Therefore, we should only use the placement groups for control planes or we will get API errors when scaling clusters.

Ideally some mechanism is added for determining how many workers will be left after the current kcli "action", such that atleast a few workers can always be included in the placement group, but right now I do not see how to determine how many workers will be in the cluster post "action", so the easier solution is to just not put workers in placement groups.