### PR TITLE
openshift: cast openshift version to string

### DIFF
--- a/kvirt/cluster/openshift/__init__.py
+++ b/kvirt/cluster/openshift/__init__.py
@@ -844,7 +844,7 @@ def create(config, plandir, cluster, overrides, dnsconfig=None):
     if '0-ec.' in str(tag):
         version = 'dev-preview'
         data['version'] = version
-    elif int(tag.split('.')[1]) > int(OPENSHIFT_TAG.split('.')[1]):
+    elif int(str(tag).split('.')[1]) > int(OPENSHIFT_TAG.split('.')[1]):
         version = 'ci'
         data['version'] = version
     if os.path.exists('coreos-installer'):


### PR DESCRIPTION
`tag: 4.17` in the parameter file is assumed to be a float and causes the following error :

```
File "/usr/lib/python3.12/site-packages/kvirt/cluster/openshift/__init__.py", line 847, in create
    elif int(tag.split('.')[1]) > int(OPENSHIFT_TAG.split('.')[1]):
             ^^^^^^^^^
AttributeError: 'float' object has no attribute 'split'
```

Use `str(tag)` as everywhere else in the `create()` function.

Fixes: 1cf856d0e92f ("openshift: imrprove ci tag detection")