### PR TITLE
Fix plans of plans

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1403,7 +1403,7 @@ When the user reprovisions, In addition to those parameters, he will be able to 
 
 ### Precreating a list of plans
 
-If you're running the same plan with different parameter files, you can simply create below the directory where your plan lives, naming them parameters_XXX.yml|yaml. The UI will then show you those as separated plans so that they can be provisioned individually applying the corresponding values from the parameter files (after merging them with the user provided data).
+If you’re running the same plan with different parameter files, you can simply create files in the directory where your plan lives, naming them parameters_XXX.yml|yaml, and/or in a subdirectory named `paramfiles`. The UI will then show you those as separated plans so that they can be provisioned individually applying the corresponding values from the parameter files (after merging them with the user provided data).
 
 ### Using several clients
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1513,7 +1513,7 @@ When the user reprovisions, In addition to those parameters, he will be able to 
 Precreating a list of plans
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you’re running the same plan with different parameter files, you can simply create below the directory where your plan lives, naming them parameters_XXX.yml|yaml. The UI will then show you those as separated plans so that they can be provisioned individually applying the corresponding values from the parameter files (after merging them with the user provided data).
+If you’re running the same plan with different parameter files, you can simply create files in the directory where your plan lives, naming them parameters_XXX.yml|yaml, and/or in a subdirectory named ``paramfiles``. The UI will then show you those as separated plans so that they can be provisioned individually applying the corresponding values from the parameter files (after merging them with the user provided data).
 
 Using several clients
 ~~~~~~~~~~~~~~~~~~~~~

--- a/kvirt/config.py
+++ b/kvirt/config.py
@@ -1709,7 +1709,7 @@ class Kconfig(Kbaseconfig):
         if inputfile is None:
             inputfile = 'kcli_plan.yml'
             pprint("using default input file kcli_plan.yml")
-        if path is not None:
+        if path not in (None, '.'):
             os.chdir(path)
             getback = True
         inputfile = os.path.expanduser(inputfile)
@@ -1887,12 +1887,9 @@ class Kconfig(Kbaseconfig):
                     path = planentry
                     if not planurl.endswith('yml'):
                         planurl = f"{planurl}/kcli_plan.yml"
-                elif '/' in planfile:
-                    path = os.path.dirname(planfile)
-                    inputfile = os.path.basename(planfile)
                 else:
-                    path = '.'
-                    inputfile = planentry
+                    path = os.path.dirname(planfile) or '.'
+                    inputfile = os.path.basename(planfile)
                 if no_overrides and parameters:
                     pprint("Using parameters from father plan in child ones")
                     for override in overrides:


### PR DESCRIPTION
Fix plan of plans that use cwd

Using plan files from the current working directory in a plan of plans
doesn't work as expected.

Assuming we have 3 plans: myplan.yaml, libvirt.yaml, and ocp.yaml all in
the same directory.

Contents of `myplan.yaml` are:

```yaml
libvirt:
  type: plan
    file: libvirt.yaml

ocp:
  type: plan
    file: ocp.yaml
```

Then we'll get error

```
Input file libvirt not found.Leaving....
```

If we explicitly say files are in the current work directory with `./`
like this:

```yaml
libvirt:
  type: plan
    file: ./libvirt.yaml

ocp:
  type: plan
    file: ./ocp.yaml
```

The the `libvirt.yaml` will be properly read, but the `ocp.yaml` won't
and we get error:

```
Input file ocp.yaml not found.Leaving....
```

This second error is caused by kcli starting the execution of the second
plan from the parent directory instead of where the execution was
started.

In this PR we fix these 2 issues and we also add to the documentation a mention of how the `paramfiles` directory is searched for files when "Exposing" a plan.