### PR TITLE
OpenShift: Web server on different IP

### DIFF
--- a/kvirt/cluster/openshift/__init__.py
+++ b/kvirt/cluster/openshift/__init__.py
@@ -509,7 +509,8 @@ def handle_baremetal_iso_sno(config, plandir, cluster, data, iso_pool=None):
                 call(f"sudo restorecon -Frvv {baremetal_web_dir}/{cluster}-*.iso", shell=True)
     else:
         call(f"sudo chmod a+r {iso_pool_path}/{cluster}-*.iso", shell=True)
-    nic = os.popen('ip r | grep default | cut -d" " -f5 | head -1').read().strip()
+    nic_name = data.get('baremetal_web_nic', 'default')
+    nic = os.popen(f'ip r | grep {nic_name} | cut -d" " -f5 | head -1').read().strip()
     ip_cmd = f"ip -o addr show {nic} | awk '{{print $4}}' | cut -d '/' -f 1 | head -1"
     host_ip = os.popen(ip_cmd).read().strip()
     if baremetal_web_port != 80:

--- a/kvirt/cluster/openshift/kcli_default.yml
+++ b/kvirt/cluster/openshift/kcli_default.yml
@@ -19,11 +19,11 @@ info: |
 version: stable
 tag: '4.17'
 pull_secret: openshift_pull.json
-image: 
+image:
 network: default
 worker_network:
-api_ip: 
-ingress_ip: 
+api_ip:
+ingress_ip:
 ctlplanes: 3
 workers: 0
 fips: false
@@ -143,6 +143,7 @@ baremetal_web: true
 baremetal_web_port: 80
 baremetal_web_dir: /var/www/html
 baremetal_sub_dir:
+baremetal_web_nic: default
 threaded: false
 ctlplanes_threaded: false
 workers_threaded: false

--- a/kvirt/cluster/openshift/sno_default.yml
+++ b/kvirt/cluster/openshift/sno_default.yml
@@ -28,3 +28,4 @@ baremetal_web: true
 baremetal_web_port: 80
 baremetal_web_dir: /var/www/html
 baremetal_sub_dir:
+baremetal_web_nic: default

--- a/kvirt/kfish/__init__.py
+++ b/kvirt/kfish/__init__.py
@@ -51,7 +51,8 @@ def get_info(url, headers):
         request = Request(chassis_url, headers=headers)
         chassis = json.loads(urlopen(request).read())['Members'][0]['@odata.id']
     except Exception as e:
-        error(f"Hit issue {e.msg} when accessing url {chassis_url}")
+        msg = getattr(e, 'msg', str(e))
+        error(f"Hit issue {msg} when accessing url {chassis_url}")
         sys.exit(1)
     request_url = f"{p.scheme}://{p.netloc}{chassis}"
     request = Request(request_url, headers=headers)


### PR DESCRIPTION
When serving ISO images for baremetal machines on the OpenShift cluster
deployment we were assuming that these were always served on the
`default` network interface, and that's the IP address that was
configured on the BMC of the baremetal server.

This only works if we are running kcli on the same network as the
servers, but that's not the case when we access them through a VPN.

In this patch we add a new configuration option named
`baremetal_web_nic` that allows us to specify the network interface we
want to use to serve the ISO.

The default value will be `default`, to maintain backward compatibility,
but for example we could set it to `tun0` when using the VPN to access
the machines to be provisioned.