### PR TITLE
kfish: Support `Image` set to `None`

### DIFF
--- a/kvirt/kfish/__init__.py
+++ b/kvirt/kfish/__init__.py
@@ -134,7 +134,8 @@ class Redfish(object):
             pprint(f"Getting {iso_url}")
         request = Request(iso_url, headers=self.headers)
         response = json.loads(urlopen(request, context=self.context).read())
-        iso = f"{response['Image']}"
+        # Image can bee set to '' or to None to indicate no image is configured
+        iso = f"{response['Image']}" if response['Image'] else ''
         inserted = response['Inserted']
         if self.debug:
             pprint(f"ISO status is Image: {iso} Inserted: {inserted}")


### PR DESCRIPTION
Some servers return `Image` set to `None` in the VirtualMedia, and current kfish code isn't expecting that, so it will consider it as a valid value, which means the code will try to disconnect it and an error will be returned by the BMC as shown below.

```
Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/kvirt/kfish/__init__.py", line 291, in set_iso
    self.eject_iso()
    ~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/kvirt/kfish/__init__.py", line 184, in eject_iso
    return urlopen(request, context=self.context)
  File "/usr/lib64/python3.13/urllib/request.py", line 189, in urlopen
    return opener.open(url, data, timeout)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/urllib/request.py", line 495, in open
    response = meth(req, response)
  File "/usr/lib64/python3.13/urllib/request.py", line 604, in http_response
    response = self.parent.error(
        'http', request, response, code, msg, hdrs)
  File "/usr/lib64/python3.13/urllib/request.py", line 533, in error
    return self._call_chain(*args)
           ~~~~~~~~~~~~~~~~^^^^^^^
  File "/usr/lib64/python3.13/urllib/request.py", line 466, in _call_chain
    result = func(*args)
  File "/usr/lib64/python3.13/urllib/request.py", line 613, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 500: Internal Server Error
```

This patch makes `None` be equivalent to '' in the `get_iso_status` method.