### PR TITLE
OpenShift: Fix deploying 2 SNOs

### DIFF
--- a/kvirt/common/__init__.py
+++ b/kvirt/common/__init__.py
@@ -2194,7 +2194,7 @@ def start_baremetal_hosts_with_iso(hosts, iso_url, overrides={}, debug=False):
             or overrides.get('bmc_password')
         if url is not None and user is not None and password is not None:
             overrides['iso_url'] = iso_url
-            overrides['sno_worker'] = index > 1 and iso_url.endswith('-sno.iso')
+            overrides['sno_worker'] = index >= 1 and iso_url.endswith('-sno.iso')
             result = start_baremetal_host(url, user, password, overrides=overrides, debug=debug)
             if result['result'] != 'success':
                 failures.append(result['reason'])


### PR DESCRIPTION
When we are deploying OpenShift of baremetal, for example with 3 master (control plane) nodes, kcli incorrectly deploys 2 nodes the `{cluster}-sno.iso` image and 1 with the `{cluster}-ctlplane.iso` image.

This happens because we are doing an incorrect check on the index when iterating over the baremeta_hosts.

This patch fixes this, so that only the first host uses the `{cluster}-sno.iso` image.