### PR TITLE
Raise right exception on `set_iso`

### DIFF
--- a/kvirt/kfish/__init__.py
+++ b/kvirt/kfish/__init__.py
@@ -294,11 +294,13 @@ class Redfish(object):
                 except Exception as e:
                     if self.debug:
                         traceback.print_exception(e)
+                    raise
             try:
                 result = self.insert_iso(iso_url)
             except Exception as e:
                 if self.debug:
                     traceback.print_exception(e)
+                raise
             if result.code not in [200, 202, 204]:
                 error(f"Hit {result.reason} When plugging {iso_url}")
                 sys.exit(1)


### PR DESCRIPTION
There are a couple of places in the `set_iso` method where an exception is not raised, so later on an invalid exception is raised, such as:

```
Hit 'NoneType' object has no attribute 'code' when plugging iso http://10.45.225.105/sno-devin-sno.iso to host with url https://devin03.mgmt.lab.eng.brq2.redhat.com/redfish/v1/Systems/System.Embedded.1
```

That `NoneType` is referring to the code trying `result.code` when `result` has not been changed from the default because an exception had been risen.

This patch fixes this error by raising the exception when it's encountered.