### PR TITLE
Fix base64 jinja filter for number like values

### DIFF
--- a/kvirt/jinjafilters/jinjafilters.py
+++ b/kvirt/jinjafilters/jinjafilters.py
@@ -25,7 +25,7 @@ def none(value):
 def base64(value):
     if value is None:
         return None
-    return str(b64encode(value.encode('utf-8')), 'utf-8')
+    return str(b64encode(str(value).encode('utf-8')), 'utf-8')
 
 
 def _type(value):


### PR DESCRIPTION
Current `base64` filter breaks if the value that it's trying to encode is an integer.

As an example, we have defined a variable:

```
password: 12345678
```

If we then have a workflow that has a file like this:

```
apiVersion: v1
kind: Secret
metadata:
  name: mysecret
  namespace: myapp
type: Opaque
data:
  AdminPassword: {{ osp_svc_password | base64 }}
```

Then kcli will fail with:

```
AttributeError: 'int' object has no attribute 'encode'
```

And it doesn't help if we try to force our variable to be a string:

```
password: "12345678"
```

This patch fixes this issue by casting the value to a string.