### PR TITLE
OpenShift: Improve EFI code in sno-finish.sh

### DIFF
--- a/kvirt/cluster/openshift/sno-finish.sh
+++ b/kvirt/cluster/openshift/sno-finish.sh
@@ -46,7 +46,7 @@ coreos-installer install --firstboot-args="${firstboot_args}" --ignition=/opt/op
 
 if [ -d /sys/firmware/efi ] ; then
  for NUM in $(efibootmgr -v | grep 'DVD\|CD\|RHCOS' | cut -f1 -d' ' | sed 's/Boot000\([0-9]\)\*/\1/'); do
-   efibootmgr -b 000$NUM -B $NUM
+   efibootmgr -b 000$NUM -B
  done
 
  mount /${install_device}2 /mnt

--- a/kvirt/cluster/openshift/sno-finish.sh
+++ b/kvirt/cluster/openshift/sno-finish.sh
@@ -45,8 +45,10 @@ echo "Executing coreos-installer with ignition file /opt/openshift/master.ign an
 coreos-installer install --firstboot-args="${firstboot_args}" --ignition=/opt/openshift/master.ign $install_device
 
 if [ -d /sys/firmware/efi ] ; then
- NUM=$(efibootmgr -v | grep 'DVD\|CD' | cut -f1 -d' ' | sed 's/Boot000\([0-9]\)\*/\1/')
- efibootmgr -b 000$NUM -B $NUM
+ for NUM in $(efibootmgr -v | grep 'DVD\|CD\|RHCOS' | cut -f1 -d' ' | sed 's/Boot000\([0-9]\)\*/\1/'); do
+   efibootmgr -b 000$NUM -B $NUM
+ done
+
  mount /${install_device}2 /mnt
  efibootmgr -d ${install_device} -p 2 -c -L RHCOS -l \\EFI\\BOOT\\BOOTX64.EFI
 fi

--- a/kvirt/cluster/openshift/sno-finish.sh
+++ b/kvirt/cluster/openshift/sno-finish.sh
@@ -45,8 +45,8 @@ echo "Executing coreos-installer with ignition file /opt/openshift/master.ign an
 coreos-installer install --firstboot-args="${firstboot_args}" --ignition=/opt/openshift/master.ign $install_device
 
 if [ -d /sys/firmware/efi ] ; then
- for NUM in $(efibootmgr -v | grep 'DVD\|CD\|RHCOS' | cut -f1 -d' ' | sed 's/Boot000\([0-9]\)\*/\1/'); do
-   efibootmgr -b 000$NUM -B
+ for NUM in $(efibootmgr -v | grep 'DVD\|CD\|RHCOS' | cut -f1 -d' ' | sed 's/Boot\([0-9,A-F,a-f]\{4\}\)\*/\1/'); do
+   efibootmgr -b $NUM -B
  done
 
  mount /${install_device}2 /mnt


### PR DESCRIPTION
This PR makes a couple of changes to the `sno-finish.sh` script related to the EFI entries:
- We start cleaning RHCOS entries, in case we are reusing the same node from a previous deployment.
- Support more than 10 EFI entries (in case we have garbage)
- Remove unnecessary $NUM at the end of the EFI deletion