### PR TITLE
spec: Use xorriso instead of genisoimage

### DIFF
--- a/kcli.spec
+++ b/kcli.spec
@@ -16,7 +16,7 @@ Source:         kcli.tar.gz
 AutoReq:        no
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  python3-devel rubygem-ronn gzip python3-setuptools git
-Requires:       python3 libvirt-python3 genisoimage nmap-ncat python3-prettytable python3-jinja2 python3-PyYAML python3-argcomplete
+Requires:       python3 libvirt-python3 xorriso nmap-ncat python3-prettytable python3-jinja2 python3-PyYAML python3-argcomplete
 
 %description
 Kcli is a wrapper for local/remote libvirt, kubevirt, vsphere, openstack, proxmox, ovirt, aws, azure, gcp, ibmcloud, packet and hcloud


### PR DESCRIPTION
genisoimage is not present on RHEL 10 (and clones), making kcli not installable on those.