### PR TITLE
App: Fix openstack-operator app installation

### DIFF
--- a/kvirt/baseconfig.py
+++ b/kvirt/baseconfig.py
@@ -996,7 +996,7 @@ class Kbaseconfig:
                 app_data['hypershift'] = True
             return common.create_app_generic(self, app, appdir, overrides=overrides, outputdir=outputdir)
         else:
-            name, catalog, channel, csv, description, namespace, channels, crds = common.olm_app(app, overrides)
+            name, catalog, channel, csv, description, namespace, channels, crds, installmode = common.olm_app(app, overrides)
             if name is None:
                 error(f"Couldn't find any app matching {app}. Skipping...")
                 return 1
@@ -1009,7 +1009,7 @@ class Kbaseconfig:
                     channel = overrides_channel
             if 'namespace' in overrides:
                 namespace = overrides['namespace']
-            app_data = {'catalog': catalog, 'channel': channel, 'namespace': namespace, 'csv': csv}
+            app_data = {'catalog': catalog, 'channel': channel, 'namespace': namespace, 'csv': csv, 'installmode': installmode}
             app_data.update(overrides)
             return common.create_app_openshift(self, app, appdir, app_data, outputdir)
 
@@ -1038,11 +1038,11 @@ class Kbaseconfig:
                 app_data['hypershift'] = True
             return common.delete_app_generic(self, app, appdir, app_data)
         else:
-            name, catalog, channel, csv, description, namespace, channels, crds = common.olm_app(app, overrides)
+            name, catalog, channel, csv, description, namespace, channels, crds, installmode = common.olm_app(app, overrides)
             if name is None:
                 error(f"Couldn't find any app matching {app}. Skipping...")
                 return 1
-            app_data = {'catalog': catalog, 'channel': channel, 'namespace': namespace, 'crds': crds}
+            app_data = {'catalog': catalog, 'channel': channel, 'namespace': namespace, 'crds': crds, 'installmode': installmode}
             app_data.update(overrides)
             return common.delete_app_openshift(self, app, appdir, app_data)
 
@@ -1074,7 +1074,7 @@ class Kbaseconfig:
     def info_app_openshift(self, app, overrides={}):
         plandir = os.path.dirname(openshift.create.__code__.co_filename)
         if app not in kdefaults.LOCAL_OPENSHIFT_APPS:
-            name, catalog, defaultchannel, csv, description, target_namespace, channels, crds = olm_app(app, overrides)
+            name, catalog, defaultchannel, csv, description, target_namespace, channels, crds, installmode = olm_app(app, overrides)
             if name is None:
                 warning(f"Couldn't find any app matching {app}")
             else:
@@ -1084,6 +1084,7 @@ class Kbaseconfig:
                 print(f"channel: {defaultchannel}")
                 print(f"target namespace: {target_namespace}")
                 print(f"csv: {csv}")
+                print(f"installmode: {installmode}")
                 print(f"description:\n{description}")
                 app = name
         appdir = f"{plandir}/apps/{app}"

--- a/kvirt/cluster/hypershift/__init__.py
+++ b/kvirt/cluster/hypershift/__init__.py
@@ -418,8 +418,8 @@ def create(config, plandir, cluster, overrides):
     kubevirt_crd_cmd = 'oc get crd hyperconvergeds.hco.kubevirt.io -o yaml 2>/dev/null'
     if kubevirt and safe_load(os.popen(kubevirt_crd_cmd).read()) is None:
         warning("Kubevirt not fully installed. Installing it for you")
-        app_name, source, channel, csv, description, x_namespace, channels, crds = olm_app('kubevirt-hyperconverged')
-        app_data = {'name': app_name, 'source': source, 'channel': channel, 'namespace': x_namespace, 'csv': csv}
+        app_name, source, channel, csv, description, x_namespace, channels, crds, installmode = olm_app('kubevirt-hyperconverged')
+        app_data = {'name': app_name, 'source': source, 'channel': channel, 'namespace': x_namespace, 'csv': csv, 'installmode': installmode}
         result = config.create_app_openshift(app_name, app_data)
         if result != 0:
             return {'result': 'failure', 'reason': "Couldnt install kubevirt properly"}
@@ -437,10 +437,10 @@ def create(config, plandir, cluster, overrides):
             warning("Hypershift needed. Installing it for you")
         if need_assisted:
             warning("Assisted needed. Installing it for you")
-        app_name, source, channel, csv, description, x_namespace, channels, crds = olm_app('multicluster-engine')
+        app_name, source, channel, csv, description, x_namespace, channels, crds, installmode = olm_app('multicluster-engine')
         app_data = {'name': app_name, 'source': source, 'channel': channel, 'namespace': x_namespace, 'csv': csv,
                     'mce_hypershift': mce_hypershift, 'assisted': need_assisted, 'version': version, 'tag': tag,
-                    'pull_secret': pull_secret}
+                    'pull_secret': pull_secret, 'installmode': installmode}
         result = config.create_app_openshift(app_name, app_data)
         if result != 0:
             return {'result': 'failure', 'reason': "Couldnt install mce properly"}

--- a/kvirt/cluster/openshift/apps/install.yml.j2
+++ b/kvirt/cluster/openshift/apps/install.yml.j2
@@ -12,8 +12,10 @@ metadata:
   name: {{ name }}-operatorgroup
   namespace: {{ namespace }}
 spec:
+{% if installmode = 'namespaced' %}
   targetNamespaces:
   - {{ namespace }}
+{% endif %}
 ---
 {% endif %}
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
When installing the `openstack-operator` it is correctly installed in the `openstack-operators` namespace, but because of this `kcli` also creates an `OperatorGroup` that is limiting the namespaces where it will take effect.

This means that following the installation of OpenStack in OpenShift will not work, and we'll get the following error when creating a valid `OpenStackControlPlane` object in the `openstack` namespace:

```
The OpenStackControlPlane "rhoso" is invalid:
* spec.galera.templates.openstack.storageClass: Required value
* spec.galera.templates.openstack-cell1.storageClass: Required value
* spec.glance.template.glanceAPIs.default.containerImage: Required value
* spec.glance.template.imageCache: Required value
* spec.barbican.template.serviceAccount: Required value
* spec.nova.template.apiContainerImageURL: Required value
* spec.nova.template.computeContainerImageURL: Required value
* spec.nova.template.conductorContainerImageURL: Required value
* spec.nova.template.metadataContainerImageURL: Required value
* spec.nova.template.novncproxyContainerImageURL: Required value
* spec.nova.template.schedulerContainerImageURL: Required value
* <nil>: Invalid value: "null": some validation rules were not checked because the object was invalid; correct the existing errors to complete validation
```

This is because the mutating webhooks are restricted by the `targetNamespaces`.

In this patch we make a small change to the `install.yml.j2` template so that the `targetNamespaces` is not created when deploying the openstack-operator.

(cherry picked from commit dee7a94d98b0d50e17a6e8866c4e627fe20c7180)