### PR TITLE
JinjaFilters: Add real_path filter

### DIFF
--- a/kvirt/jinjafilters/jinjafilters.py
+++ b/kvirt/jinjafilters/jinjafilters.py
@@ -204,6 +204,10 @@ def pwd_path(path):
         return path
 
 
+def real_path(path):
+    return path and os.path.realpath(path)
+
+
 def min_ocp_version(version1, version2):
     return version1 if version1 < version2 else version2
 
@@ -217,7 +221,7 @@ jinjafilters = {'basename': basename, 'dirname': dirname, 'kubenodes': kubenodes
                 'defaultnodes': defaultnodes, 'wait_crd': wait_crd, 'local_ip': local_ip, 'network_ip': network_ip,
                 'kcli_info': kcli_info, 'find_manifests': find_manifests, 'exists': exists, 'ipv6_wrap': ipv6_wrap,
                 'has_ctlplane': has_ctlplane, 'wait_csv': wait_csv, 'count': count, 'pwd_path': pwd_path,
-                'min_ocp_version': min_ocp_version, 'max_ocp_version': max_ocp_version}
+                'min_ocp_version': min_ocp_version, 'max_ocp_version': max_ocp_version, 'real_path': real_path}
 
 
 class FilterModule(object):


### PR DESCRIPTION
This patch adds a `real_path` jinja filter allowing us to have parameters that specify a file's location relative to the root plan location and then be usable within a script.

As an example:

kcli_parameters.yaml
```
osp_edpm_key=keys/id_ed25519
```

secrets.sh
```
edpm_key="{{ osp_edpm_key | real_path }}"

oc create secret generic dataplane-ansible-ssh-private-key-secret \
  -n openstack \
  --save-config --dry-run=client -o yaml \
  --from-file="ssh-privatekey=${edpm_key}" \
  --from-file="ssh-publickey=${edpm_key}.pub" \ | oc apply -f -
```

kcli_plan.yml
```
edpm:
  type: workflow
  destdir: ./out
  scripts:
  - secrets.sh
```

(cherry picked from commit 483b9e58051989453bdcc3d6a2853c3aa7813532)