### PR TITLE
Workflows: Support recursive directories

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1344,6 +1344,38 @@ Will create the following file structure:
 ./outdir/frout.j2
 ```
 
+When using a directory in a `files` section the structure will be recreated and all files within it will be rendered.
+
+If we have this file structure:
+
+```
+./arch/frout.sh
+./arch/frout.txt
+./arch/frout.j2
+./arch/subdir/anotherfile.sh
+```
+
+And we use this workflow:
+
+```YAML
+myworkflow:
+  type: workflow
+  destdir: outdir
+  scripts:
+  - arch/frout.sh
+  files:
+  - origin: arch
+```
+
+We'll end up with the following:
+
+```
+./outdir/frout.sh
+./outdir/arch/frout.txt
+./outdir/arch/frout.j2
+./outdir/arch/subdir/anotherfile.sh
+```
+
 ### vms
 You can point at an existing profile in your plans, define all parameters for the vms, or combine both approaches. You can even add your own profile definitions in the plan file and reference them within the same plan:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1446,6 +1446,40 @@ Will create the following file structure:
    ./outdir/frout.txt
    ./outdir/frout.j2
 
+
+When using a directory in a ``files`` section the structure will be recreated and all files within it will be rendered.
+
+If we have this file structure:
+
+::
+
+   ./arch/frout.sh
+   ./arch/frout.txt
+   ./arch/frout.j2
+   ./arch/subdir/anotherfile.sh
+
+
+And we use this workflow:
+
+.. code:: yaml
+
+   myworkflow:
+     type: workflow
+     destdir: outdir
+     scripts:
+     - arch/frout.sh
+     files:
+     - origin: arch
+
+We'll end up with the following:
+
+::
+
+   ./outdir/frout.sh
+   ./outdir/arch/frout.txt
+   ./outdir/arch/frout.j2
+   ./outdir/arch/subdir/anotherfile.sh
+
 vms
 ~~~
 

--- a/kvirt/baseconfig.py
+++ b/kvirt/baseconfig.py
@@ -1282,7 +1282,7 @@ class Kbaseconfig:
             if 'path' in entry:
                 destdir = os.path.dirname(entry['path'])
             else:
-                destdir = f"{destdir}/{os.path.dirname(entry['origin'])}"
+                destdir = f"{outputdir}/{os.path.dirname(entry['origin'])}"
             if not os.path.exists(destdir):
                 pprint(f"Creating directory {destdir}")
                 os.makedirs(destdir)


### PR DESCRIPTION
Workflows: Support recursive directories

Current workflow code only supports files within a single directory.

This patch adds the functionality to support recursive directories, so
a workflow like this:

```
ctrlplane:
  type: workflow
  destdir: ./out
  scripts:
  - scripts/ctrlplane.sh
  files:
  - origin: ctrl
```

Will work with the file structure:

```
├── ctrl
│   ├── 00-openstack-ns.yaml
│   ├── 00-operators
│   │   ├── 00-operator-cert-manager.yaml
│   │   ├── 00-operator-cluster-observability.yam
│   │   ├── 00-operator-metallb.yaml
│   │   ├── 00-operator-nmstate.yaml
│   │   └── 00-operator-openstack.yaml
```

In this PR we also fix workflow files without path, because on commit f909009e669e8ca926ff2fa1713ace9ce8cf7b54 the workflow code was
cleaned up, but it broke files that had no `path`.

Error shown is similar to this:

```
    destdir = f"{destdir}/{os.path.dirname(entry['origin'])}"
                 ^^^^^^^
UnboundLocalError: cannot access local variable 'destdir' where it is not associated with a value
```

That's because in the previously mentioned commit variable
`default_destdir` that was removed was accidentally changed to `destdir`
instead of `outputdir`.