### PR TITLE
OpenStack: Fix using password

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -501,6 +501,7 @@ myopenstack:
 The following parameters are specific to openstack:
 
 - `envrc` (Optional) Path to an envrc file
+- `auth_type` (Optional). Indicates the type of authentication to use. Will auto detect based on parameters when empty. Values: `token`, `password`, `v3applicationcredential`.
 - `auth_url`
 - `project`
 - `domain` Defaults to *Default*

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -516,6 +516,7 @@ Openstack provider
 The following parameters are specific to openstack:
 
 - ``envrc`` (Optional) Path to an envrc file
+- ``auth_type`` (Optional). Indicates the type of authentication to use. Will auto detect based on parameters when empty. Values: ``token``, ``password``, ``v3applicationcredential``.
 - ``auth_url``
 - ``project``
 - ``domain`` Defaults to *Default*

--- a/kvirt/config.py
+++ b/kvirt/config.py
@@ -272,6 +272,9 @@ class Kconfig(Kbaseconfig):
                 glance_disk = options.get('glance_disk', False)
                 auth_token = options.get('token') or os.environ.get("OS_TOKEN") or 'password'
                 default_auth_type = 'token' if auth_token is not None else 'password'
+                application_credential_id = None
+                application_credential_secret = None
+
                 auth_type = options.get('auth_type') or os.environ.get("OS_AUTH_TYPE") or default_auth_type
                 if auth_type == 'password' and password is None:
                     error("Missing password in the configuration. Leaving")

--- a/kvirt/config.py
+++ b/kvirt/config.py
@@ -270,7 +270,7 @@ class Kconfig(Kbaseconfig):
                     error(f"Indicated ca_file {ca_file} not found. Leaving")
                     sys.exit(1)
                 glance_disk = options.get('glance_disk', False)
-                auth_token = options.get('token') or os.environ.get("OS_TOKEN") or 'password'
+                auth_token = options.get('token') or os.environ.get("OS_TOKEN")
                 default_auth_type = 'token' if auth_token is not None else 'password'
                 application_credential_id = None
                 application_credential_secret = None


### PR DESCRIPTION
When we are using the OpenStack provider with password it fails due to missing variables, this patch fixes it.