### PR TITLE
Add missing space for gcp pip3 install command

### DIFF
--- a/kvirt/common/__init__.py
+++ b/kvirt/common/__init__.py
@@ -2382,7 +2382,7 @@ def install_provider(provider, pip=False):
         if not pip:
             warning("Using pip as this is the only way for this provider")
         cmd = 'pip3 install google-api-python-client google-auth-httplib2 google-cloud-dns google-cloud-storage'
-        cmd += 'google-cloud-compute google-cloud-container'
+        cmd += ' google-cloud-compute google-cloud-container'
     elif provider == 'ibm':
         if not pip:
             warning("Using pip as this is the only way for this provider")


### PR DESCRIPTION
Command was by accident:
pip3 install google-cloud-storagegoogle-cloud-compute

This PR fixes it to be:
pip3 install google-cloud-storage google-cloud-compute