### PR TITLE
Don't explicitly specify server/agent in k3s install command

### DIFF
--- a/kvirt/cluster/k3s/bootstrap.sh
+++ b/kvirt/cluster/k3s/bootstrap.sh
@@ -23,7 +23,7 @@ export IP={{ api_ip }}
 export IP=$(hostname -I | cut -f1 -d" ")
 {% endif %}
 
-curl -sfL https://get.k3s.io | {{ install_k3s_args }} K3S_TOKEN={{ token }} sh -s - server {{ '--cluster-init' if ctlplanes > 1 else '' }} {{ extra_args|join(" ") }} {{ '--tls-san $IP' if not cloud_lb and config_type in ['aws', 'gcp', 'ibmcloud'] else '' }}
+curl -sfL https://get.k3s.io | {{ install_k3s_args }} K3S_TOKEN={{ token }} sh -s - {{ '--cluster-init' if ctlplanes > 1 else '' }} {{ extra_args|join(" ") }} {{ '--tls-san $IP' if not cloud_lb and config_type in ['aws', 'gcp', 'ibmcloud'] else '' }}
 export K3S_TOKEN=$(cat /var/lib/rancher/k3s/server/node-token)
 sed "s/127.0.0.1/$IP/" /etc/rancher/k3s/k3s.yaml > /root/kubeconfig
 if [ -d /root/manifests ] ; then

--- a/kvirt/cluster/k3s/ctlplanes.sh
+++ b/kvirt/cluster/k3s/ctlplanes.sh
@@ -32,4 +32,4 @@ export IP={{ first_ip }}
 {% set first_ip = '{}-{}'.format(cluster, node_suffix) | kcli_info('ip', client) %}
 {% endif %}
 
-curl -sfL https://get.k3s.io | {{ install_k3s_args|default("") }} K3S_TOKEN={{ token }} sh -s - server --server https://{{ first_ip }}:6443 {{ extra_args|join(" ") }} --tls-san $IP
+curl -sfL https://get.k3s.io | {{ install_k3s_args|default("") }} K3S_TOKEN={{ token }} sh -s - --server https://{{ first_ip }}:6443 {{ extra_args|join(" ") }} --tls-san $IP

--- a/kvirt/cluster/k3s/join.sh
+++ b/kvirt/cluster/k3s/join.sh
@@ -4,4 +4,4 @@
 {% set api_ip = '{0}-ctlplane-1'.format(cluster)|kcli_info('ip') if scale|default(False) and 'ctlplane-0' in name else first_ip %}
 {% endif %}
 
-curl --retry 5 -sfL https://get.k3s.io | K3S_URL=https://{{ api_ip }}:6443 K3S_TOKEN={{ token }} {{ install_k3s_args|default([])|join(' ') }} sh -s - agent {{ extra_args|join(' ') }}
+curl --retry 5 -sfL https://get.k3s.io | K3S_URL=https://{{ api_ip }}:6443 K3S_TOKEN={{ token }} {{ install_k3s_args|default([])|join(' ') }} sh -s - {{ extra_args|join(' ') }}


### PR DESCRIPTION
The K3S install script will autodetect based on K3S_URL, whether or the node is a server or agent node and insert in the (systemd unit file, or whatever is relevant for your OS) command.

Specifying explicitly runs the risk of having server/agent specified twice in the k3s command which would happen if INSTALL_K3S_EXEC='--flannel-backend=none' was set for that specific server installation.
In that case the K3S install script does not realize that the user has already specified server/agent and will therefore add a duplicate server/agent definition.

Therefore, let the k3s install script handle the detection.