### PR TITLE
OpenStack: Fix VM deletion

### DIFF
--- a/kvirt/providers/openstack/__init__.py
+++ b/kvirt/providers/openstack/__init__.py
@@ -513,6 +513,15 @@ class Kopenstack(object):
                 if entry2['OS-EXT-IPS:type'] == 'floating':
                     vm_floating_ips.append(entry2['addr'])
         vm.delete()
+
+        # Wait until it's gone
+        while True:
+            try:
+                nova.servers.get(vm.id)
+                sleep(1)
+            except novaclient.exceptions.NotFound:
+                break
+
         for floating in vm_floating_ips:
             floatingid = floating_ips[floating]
             try:


### PR DESCRIPTION
When deleting an OpenStack instance, for example the bootstrap node when deploying OCP or OCP itself on cluster cleanup, we are likely to encounter an error similar to this one:

```
cinderclient.exceptions.ClientException: ConflictNovaUsingAttachment: Detach volume from instance 0b54b909-43d8-4968-a183-c82004ad1e2e using the Compute API (HTTP 409) (Request-ID: req-2f8babd2-3aac-491e-83fa-032810da8880)
```

Which is caused by kcli being too fast to delete the volumes and requesting their deletion before the VM has actually stopped using them.

This patch fixes this by making sure we don't try to delete volumes until the nova instance has disappeared, at which point its resources would have been freed.