### PR TITLE
Add unitnumber to vsphere iso connect/disconnect

### DIFF
--- a/kvirt/providers/vsphere/helpers.py
+++ b/kvirt/providers/vsphere/helpers.py
@@ -310,6 +310,7 @@ def changecd(si, vm, iso):
             cdromspec.device.connectable.allowGuestControl = True
             cdromspec.device.controllerKey = virtual_cdrom_device.controllerKey
             cdromspec.device.key = virtual_cdrom_device.key
+            cdromspec.device.unitNumber = virtual_cdrom_device.unitNumber
             if iso is not None:
                 cdromspec.device.backing = vim.vm.device.VirtualCdrom.IsoBackingInfo()
                 cdromspec.device.backing.fileName = iso


### PR DESCRIPTION
We recently updated our vsphere to 8.0.3. If unitnumber is not set, disconnecting an ISO/cdrom results in an unclear error: "The attempted operation cannot be performed in the current state (Powered on)"

Setting unitnumber, makes vsphere behave as expected on ISO disconnect again.
I expect that setting unitnumber will not hurt prior versions as I believe it has been in the spec for a long time.