### PR TITLE
Add list image function to hcloud and support more 'list image' responses

### DIFF
--- a/kvirt/cli.py
+++ b/kvirt/cli.py
@@ -1120,6 +1120,8 @@ def list_images(args):
     imagestable = PrettyTable(["Images"])
     imagestable.align["Images"] = "l"
     for image in images:
+        if isinstance(image, dict):
+            image = image.get('name')
         imagestable.add_row([image])
     print(imagestable)
 

--- a/kvirt/providers/hcloud/__init__.py
+++ b/kvirt/providers/hcloud/__init__.py
@@ -442,8 +442,18 @@ class Khcloud():
 
         return info["ip"]
 
-    def volumes(self, iso=True):
-        return glob.glob('*.iso')
+    def volumes(self, iso=False):
+        images = self.conn.images.get_all()
+        results = []
+        for image in images:
+            results.append({ 
+                'name': image.name or image.id,
+                'id': image.id_or_name,
+                'description': image.description,
+                'type': image.type,
+                'architecture': image.architecture
+            })
+        return results
 
     def add_image(self, url, pool, cmd=None, name=None, size=None, convert=False):
         os.system("curl -Lk %s > %s" % (url, os.path.basename(url)))


### PR DESCRIPTION
Adds 'list image' functionality to the hcloud provider.

Also adds support for more advanced 'list image' return, which is useful for my uses of hcloud, but I also feel it will be useful for other providers in the future, since the current 'list image' return is very barebones. Unless -o json/yaml is used, only the name is returned.

If other providers start taking advantage of this by returning objects, then backwards compatibility is obviously broken. I don't know how bad you feel that would be, but in that case maybe implementing a 'list image --detailed' arg might be necessary.