### PR TITLE
hcloud: Don't let labels overwrite already set keys

### DIFF
--- a/kvirt/providers/hcloud/__init__.py
+++ b/kvirt/providers/hcloud/__init__.py
@@ -302,7 +302,8 @@ class Khcloud():
         if vm.labels:
             for key, value in vm.labels.items():
                 if key in METADATA_FIELDS:
-                    yamlinfo[key] = value
+                    if yamlinfo.get(key) is None:
+                        yamlinfo[key] = value
         if debug:
             yamlinfo['debug'] = vm
         return yamlinfo


### PR DESCRIPTION
Simple bugfix that ensures that the 'image' key of 'kcli info vm <vm>' is prioritized from the vm object rather than the set vm labels. Ensures this for all other keys too.