### PR TITLE
Add custom url for the image

### DIFF
--- a/kvirt/cluster/openshift/kcli_default.yml
+++ b/kvirt/cluster/openshift/kcli_default.yml
@@ -179,3 +179,4 @@ techpreview: false
 mirror_dir:
 ksushy_ip: 192.168.122.1
 ksushy_port: 9000
+image_url:


### PR DESCRIPTION
The image_url allows to supply a custom image for the openshift cluster. This is particularly useful to test fixes or new features which needs to be included in the coreos image.