### PR TITLE
Add option to use slirp for usermode

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -836,6 +836,12 @@ kcli create vm -i centos9stream -P nets=['{"name": "default", "type": "e1000"}']
 
 Again, both syntaxes can be combined
 
+It is also possible to leverage user mode networking with a couple of plugins, `slirp` and `passt`, and you can ssh into them
+```Shell
+kcli create vm -i centos9stream -P usermode=true -P usermode_backend=slirp vm-slirp
+kcli create vm -i centos9stream -P usermode=true -P usermode_backend=passt vm-passt
+```
+
 ### Injecting files
 
 You can inject a list of `files` in your vms. For instance, to inject a file named myfile.txt, use

--- a/kvirt/defaults.py
+++ b/kvirt/defaults.py
@@ -204,7 +204,7 @@ oEO8BRcXIiXiQqW9KnF99fXOiQ/cKYh3kWBBPnuEOhC77Ke5aMlqMNOPULf3PMix
 -----END CERTIFICATE-----"""
 VIRTTYPE = None
 METADATA_FIELDS = ['dnsclient', 'domain', 'image', 'kube', 'kubetype', 'loadbalancer', 'owner', 'plan', 'profile',
-                   'user', 'redfish_iso', 'cluster_network', 'userport']
+                   'user', 'redfish_iso', 'cluster_network', 'userport', 'usermode_backend']
 VMRULES = []
 VMRULES_STRICT = False
 SECURITYGROUPS = []

--- a/kvirt/keywords.yaml
+++ b/kvirt/keywords.yaml
@@ -139,6 +139,13 @@ tunneldir: Specific directory on the tunnel host where to store ignition files
 tunnelhost: Specific host to use for tunneling console, ssh and scp commands
 tunnelport: Specific port to use for tunneling console, ssh and scp commands
 tunneluser: Specific user to use for tunneling console, ssh and scp commands
+usermode: |
+  Enable user mode networking for the VM. When enabled, the VM will use user mode networking instead of bridged or NAT networking.
+  Automatically sets up port forwarding for SSH (port 22) to a random host port.
+usermode_backend: |
+  Backend to use for user mode networking. Options are:
+  - passt (default): Modern usermode networking backend with better performance
+  - slirp: Traditional usermode networking backend, more widely compatible
 virttype: |
   Only used for libvirt where it evaluates to kvm if acceleration shows in capabilities, or qemu emulation otherwise.
   If a value is provided, it must be either kvm, qemu, xen or lxc

--- a/kvirt/providers/kvm/__init__.py
+++ b/kvirt/providers/kvm/__init__.py
@@ -233,6 +233,7 @@ class Kvirt(object):
             self.url = 'qemu:///session'
             userport = common.get_free_port()
             metadata['userport'] = userport
+            metadata['usermode_backend'] = overrides.get('usermode_backend', 'passt')
             usermode = True
         if self.exists(name):
             return {'result': 'failure', 'reason': f"VM {name} already exists"}
@@ -736,9 +737,15 @@ class Kvirt(object):
             if netname in ovsnetworks:
                 ovs = True
             if usermode:
-                iftype = 'user'
-                sourcexml = "<backend type='passt'/>"
-                sourcexml += f"<portForward proto='tcp'><range start='{userport}' to='22'/></portForward>"
+                usermode_backend = overrides.get('usermode_backend', 'passt')
+                if usermode_backend == 'slirp':
+                    # Skip libvirt interface for slirp - handled via QEMU command line
+                    continue
+                else:
+                    # Default to passt
+                    iftype = 'user'
+                    sourcexml = "<backend type='passt'/>"
+                    sourcexml += f"<portForward proto='tcp'><range start='{userport}' to='22'/></portForward>"
             elif netname in networks:
                 iftype = 'network'
                 sourcexml = f"<source network='{netname}'/>"
@@ -1099,7 +1106,8 @@ class Kvirt(object):
             vcpuxml = f"<vcpu>{numcpus}</vcpu>"
         clockxml = "<clock offset='utc'/>"
         qemuextraxml = ''
-        if ignition or macosx or tpm or qemuextra is not None or nvmedisks:
+        usermode_backend = overrides.get('usermode_backend', 'passt') if usermode else None
+        if ignition or macosx or tpm or qemuextra is not None or nvmedisks or (usermode and usermode_backend == 'slirp'):
             namespace = "xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'"
             ignitionxml = ""
             if ignition:
@@ -1141,12 +1149,19 @@ class Kvirt(object):
 <qemu:arg value='file={diskpath},format=qcow2,if=none,id=NVME{index}'/>
 <qemu:arg value='-device'/>
 <qemu:arg value='nvme,drive=NVME{index},serial=nvme-{index}'/>""".format(index=index, diskpath=diskpath)
+            slirpxml = ""
+            if usermode and usermode_backend == 'slirp':
+                slirpxml = f"""<qemu:arg value='-netdev'/>
+<qemu:arg value='user,id=net0,hostfwd=tcp::{userport}-:22'/>
+<qemu:arg value='-device'/>
+<qemu:arg value='virtio-net-pci,netdev=net0,addr=0x10'/>"""
             qemuextraxml = """<qemu:commandline>
 {ignitionxml}
 {macosxml}
 {freeformxml}
 {nvmexml}
-</qemu:commandline>""".format(ignitionxml=ignitionxml, macosxml=macosxml, freeformxml=freeformxml, nvmexml=nvmexml)
+{slirpxml}
+</qemu:commandline>""".format(ignitionxml=ignitionxml, macosxml=macosxml, freeformxml=freeformxml, nvmexml=nvmexml, slirpxml=slirpxml)
         sharedxml = ""
         if sharedfolders:
             for folder in sharedfolders:
@@ -1889,6 +1904,9 @@ class Kvirt(object):
             e = element.find('{kvirt}userport')
             if e is not None:
                 yamlinfo['userport'] = e.text
+            e = element.find('{kvirt}usermode_backend')
+            if e is not None:
+                yamlinfo['usermode_backend'] = e.text
         if image is not None:
             yamlinfo['image'] = image
         yamlinfo['plan'] = plan


### PR DESCRIPTION
Besides `passt` this PR adds supports for another usermode networking plugin, `slirp`.
`slirp` is needed because unfortunately is not possible to run `passt` within flatpaks, while `slirp` works properly.
Both plugins allows the user to ssh into the VM.

Both plugins were tested with ssh access to the VM :heavy_check_mark: and the documentation was updated with examples.