### PR TITLE
kvm: improve SSH handling for local connections in thinimages method

### DIFF
--- a/kvirt/providers/kvm/__init__.py
+++ b/kvirt/providers/kvm/__init__.py
@@ -3831,7 +3831,11 @@ class Kvirt(object):
     def thinimages(self, path, thinpool):
         thincommand = ("lvs -o lv_name  %s -S 'lv_attr =~ ^V && origin = \"\" && pool_lv = \"%s\"'  --noheadings"
                        % (path, thinpool))
-        if self.protocol == 'ssh':
+        # Avoid SSH wrapping when effectively local (either explicit local URL or localhost host)
+        use_ssh = (self.protocol == 'ssh' and not (
+            self.host in ['localhost', '127.0.0.1'] or (self.url is not None and self.url.startswith('qemu:///'))
+        ))
+        if use_ssh:
             thincommand = "ssh %s -p %s %s@%s \"%s\"" % (self.identitycommand, self.port, self.user, self.host,
                                                          thincommand)
         results = os.popen(thincommand).read().strip()


### PR DESCRIPTION
When attempting to create a new virtual machine using provider kvm after creating a thin pool, I received this error. 

# kcli create vm my-nvme-vm -i centos9stream -P disks='[{"size":20,"pool":"default"}]'
root@127.0.0.1's password: 

 File "/usr/lib/python3.9/site-packages/kvirt/providers/kvm/__init__.py", line 2103, in volumes
    for volume in self.thinimages(poolpath, thinpool):
  File "/usr/lib/python3.9/site-packages/kvirt/providers/kvm/__init__.py", line 3837, in thinimages
    results = os.popen(thincommand).read().strip()
KeyboardInterrupt

I checked the KVM provider code paths: even with a local libvirt URL, it wraps lvs in SSH whenever the client protocol is set to 'ssh'. 

This is my first project contribution. Please feel free to offer input. 