### PR TITLE
allow yaml files to have yaml extension

### DIFF
--- a/kvirt/cli.py
+++ b/kvirt/cli.py
@@ -1503,7 +1503,7 @@ def create_vm(args):
             pprint(f"Using {image} as profile")
         profile = image
     elif profile is not None:
-        if profile.endswith('.yml'):
+        if profile.endswith('.yml') or profile.endswith('.yaml'):
             profilefile = profile
             profile = None
             if not os.path.exists(profilefile):

--- a/kvirt/config.py
+++ b/kvirt/config.py
@@ -1550,7 +1550,7 @@ class Kconfig(Kbaseconfig):
         if url is not None:
             if url.startswith('/'):
                 url = f"file://{url}"
-            if not url.endswith('.yml'):
+            if not url.endswith('.yml') and not url.endswith('.yaml'):
                 url = f"{url}/kcli_plan.yml"
                 pprint(f"Trying to retrieve {url}")
             inputfile = os.path.basename(url)
@@ -1800,7 +1800,7 @@ class Kconfig(Kbaseconfig):
                     continue
                 elif planurl is not None:
                     path = planentry
-                    if not planurl.endswith('yml'):
+                    if not planurl.endswith('yml') and not planurl.endswith('yaml'):
                         planurl = f"{planurl}/kcli_plan.yml"
                 else:
                     path = os.path.dirname(planfile) or '.'


### PR DESCRIPTION
Provisioning with a plan file ending in .yaml instead of .yml results in error, because kcli appends `kcli_plan.yml` suffix.

```
kcli create plan -P k8s=true -u https://github.com/rccrdpccl/kcli-manifests/blob/master/k8s-interactive.yaml -P student=testme testme
Trying to retrieve https://github.com/rccrdpccl/kcli-manifests/blob/master/k8s-interactive.yaml/kcli_plan.yml
Retrieving specified plan from https://github.com/rccrdpccl/kcli-manifests/blob/master/k8s-interactive.yaml/kcli_plan.yml to testme
Hit issue with url https://raw.githubusercontent.com/rccrdpccl/kcli-manifests/master/k8s-interactive.yaml/kcli_plan.yml
```