### PR TITLE
Add installer_url parameter for custom openshift-install download

### DIFF
--- a/kvirt/baseconfig.py
+++ b/kvirt/baseconfig.py
@@ -1061,8 +1061,11 @@ class Kbaseconfig:
         baremetal = overrides.get('baremetal') or False
         tag = overrides.get('tag') or OPENSHIFT_TAG
         version = overrides.get('version') or detect_openshift_version(tag, OPENSHIFT_TAG)
+        installer_url = overrides.get('installer_url')
         macosx = os.path.exists('/Users')
-        if okd:
+        if installer_url:
+            run = openshift.get_installer_from_url(installer_url, debug=self.debug)
+        elif okd:
             run = openshift.get_okd_installer(tag, version=version, debug=self.debug)
         elif version in ['ci', 'nightly']:
             nightly = version == 'nightly'

--- a/kvirt/cluster/openshift/kcli_default.yml
+++ b/kvirt/cluster/openshift/kcli_default.yml
@@ -18,6 +18,7 @@ info: |
     baremetal_hosts can be specified as an array of bmc urls to deploy baremetal workers (or in the case of SNO described before)
 version: stable
 tag: '4.20'
+installer_url:
 pull_secret: openshift_pull.json
 image:
 network: default

--- a/kvirt/examples.py
+++ b/kvirt/examples.py
@@ -662,6 +662,9 @@ $ kcli download openshift-install -P tag=4.20.0-rc.1
 
 # Download older version from CI
 $ kcli download openshift-install -P version=ci -P tag=4.14
+
+# Download from custom URL
+$ kcli download openshift-install -P installer_url=https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/candidate-4.20
 """
 
 securitygroupcreate = """# Create a security group named mygroup and opening tcp ports 22 and 25


### PR DESCRIPTION
The stable folder for openshift-installer may lag behind actual releases (e.g., stable have now 4.20.4 while 4.20.5 is already available).

This parameter allows downloading from custom locations like candidate or specific version folders, For example https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/candidate-4.20/