### PR TITLE
kvm: set firewalld zone for libvirt network

### DIFF
--- a/kvirt/cli.py
+++ b/kvirt/cli.py
@@ -2745,6 +2745,7 @@ def create_network(args):
     dhcp = overrides.get('dhcp')
     nodhcp = not dhcp if dhcp is not None else args.nodhcp
     domain = overrides.get('domain') or args.domain
+    fwzone = overrides.get('fwzone') or args.fwzone
     plan = overrides.get('plan', 'kvirt')
     config = Kconfig(client=args.client, debug=args.debug, region=args.region, zone=args.zone, namespace=args.namespace)
     k = config.k
@@ -2757,7 +2758,7 @@ def create_network(args):
         overrides['dual_cidr'] = args.dual
     if args.dualname is not None:
         overrides['dual_name'] = args.dualname
-    result = k.create_network(name=name, cidr=cidr, dhcp=dhcp, nat=nat, domain=domain, overrides=overrides, plan=plan)
+    result = k.create_network(name=name, cidr=cidr, dhcp=dhcp, nat=nat, domain=domain, fwzone=fwzone, overrides=overrides, plan=plan)
     common.handle_response(result, name, element='Network')
 
 

--- a/kvirt/config.py
+++ b/kvirt/config.py
@@ -1742,7 +1742,8 @@ class Kconfig(Kbaseconfig):
                     continue
                 dhcp = netprofile.get('dhcp', True)
                 domain = netprofile.get('domain')
-                result = z.create_network(name=net, cidr=cidr, dhcp=dhcp, nat=nat, domain=domain, plan=plan,
+                fwzone = netprofile.get('fwzone')
+                result = z.create_network(name=net, cidr=cidr, dhcp=dhcp, nat=nat, domain=domain, fwzone=fwzone, plan=plan,
                                           overrides=netprofile)
                 common.handle_response(result, net, element='Network')
         if poolentries and not onlyassets:

--- a/kvirt/providers/kvm/__init__.py
+++ b/kvirt/providers/kvm/__init__.py
@@ -3430,7 +3430,7 @@ class Kvirt(object):
         pool.refresh()
         return {'result': 'success'}
 
-    def create_network(self, name, cidr=None, dhcp=True, nat=True, domain=None, plan='kvirt', overrides={}):
+    def create_network(self, name, cidr=None, dhcp=True, nat=True, domain=None, fwzone=None, plan='kvirt', overrides={}):
         conn = self.conn
         networks = self.list_networks()
         if name in networks:
@@ -3539,7 +3539,10 @@ class Kvirt(object):
             domainxml = f"<domain name='{name}' localOnly='{localdomain}'/>"
         if len(name) < 16:
             bridgename = name if name != 'default' else 'virbr0'
-            bridgexml = f"<bridge name='{bridgename}' stp='on' delay='0'/>"
+            if fwzone is not None:
+                bridgexml = f"<bridge name='{bridgename}' zone='{fwzone}' stp='on' delay='0'/>"
+            else:
+                bridgexml = f"<bridge name='{bridgename}' stp='on' delay='0'/>"
         else:
             return {'result': 'failure', 'reason': f"network {name} is more than 16 characters"}
         prefix = cidr.split('/')[1]


### PR DESCRIPTION
This PR add the parameter fwzone to the network definition in order to put libvirt network in required firewalld zone.