### PR TITLE
[openstack] improve floating ips and router external gateway handling when external_network parameter is defined

### DIFF
--- a/kvirt/providers/openstack/__init__.py
+++ b/kvirt/providers/openstack/__init__.py
@@ -890,8 +890,12 @@ class Kopenstack(object):
 
     def create_network(self, name, cidr=None, dhcp=True, nat=True, domain=None, plan='kvirt', overrides={}):
         if nat:
-            externalnets = [n for n in self.neutron.list_networks()['networks'] if n['router:external']]
-            externalnet_id = externalnets[0]['id'] if externalnets else None
+            if self.external_network is not None:
+                external_networks = self.neutron.list_networks(name=self.external_network)['networks']
+                externalnet_id = external_networks[0]['id']
+            else:
+                externalnets = [n for n in self.neutron.list_networks()['networks'] if n['router:external']]
+                externalnet_id = externalnets[0]['id'] if externalnets else None
             routers = [router for router in self.neutron.list_routers()['routers'] if router['name'] == 'kvirt']
             router_id = routers[0]['id'] if routers else None
         try:


### PR DESCRIPTION
**Commit #1 - [openstack] random available fip from random external network might be chosen even if external_network is defined**

Defining "external_network" parameter at (openstack) provider level, i'm expecting needed floating ips (i.e. to deploy an Openshift cluster) to be picked from that network.
When multiple external networks are configured (i.e. provider networks) and a fip is available from there, this might be automatically selected. Most of time, the deployment will fails because that external network is not even attached to the kvirt router.

Commit #2 - [openstack] random external network is chosen even if external_network is defined 

Defining "external_network" parameter at (openstack) provider level, i'm expecting "kvirt" router being created using it as external-gateway.

When multiple external networks exist (i.e. provider networks) the first one is randomly chosen, instead.