### PR TITLE
[openstack] using delete_on_termination we don't need to manually delete volumes

### DIFF
--- a/kvirt/providers/openstack/__init__.py
+++ b/kvirt/providers/openstack/__init__.py
@@ -548,6 +548,8 @@ class Kopenstack(object):
                 volume = cinder.volumes.get(disk['id'])
             except cinderclient.exceptions.NotFound:
                 continue
+            if volume.status == "deleting":
+                continue
             for attachment in volume.attachments:
                 if attachment['server_id'] == vm.id:
                     cinder.volumes.detach(volume, attachment['attachment_id'])


### PR DESCRIPTION
Openstack volumes are created with delete_on_termination set to True, so once we delete i.e. an ocp cluster, volumes that belongs to Openshift nodes will be in deleting state when current code tries to delete them, generating an error.