### PR TITLE
Fixes issue with ordering

### DIFF
--- a/kvirt/jinjafilters/jinjafilters.py
+++ b/kvirt/jinjafilters/jinjafilters.py
@@ -218,14 +218,11 @@ def read_file(path):
     with open(path, 'r') as f:
         return f.read()
 
+def max_ocp_version(version1, version2):
+    return max(version1, version2, key=lambda v: tuple(map(int, v.split("."))))
 
 def min_ocp_version(version1, version2):
-    return version1 if version1 < version2 else version2
-
-
-def max_ocp_version(version1, version2):
-    return version1 if version1 > version2 else version2
-
+    return min(version1, version2, key=lambda v: tuple(map(int, v.split("."))))
 
 def filter_bgp_peers(peers, num):
     peers = peers.copy()


### PR DESCRIPTION
The previous code was not handling the ordering correctly.

```python
def min_ocp_version(version1, version2):
    return version1 if version1 < version2 else version2


def max_ocp_version(version1, version2):
    return version1 if version1 > version2 else version2


print(max_ocp_version("4.20.8", "4.20.10"))
print(min_ocp_version("4.20.8", "4.20.10"))
```

This was reporting:

```output
4.20.8
4.20.10
```

New functions do the comparison numerically rather than lexically.