### PR TITLE
kube generic: fix feature_gates extraArgs format for kubeadm v1beta3

### DIFF
--- a/kvirt/cluster/kubeadm/__init__.py
+++ b/kvirt/cluster/kubeadm/__init__.py
@@ -243,9 +243,9 @@ def create(config, plandir, cluster, overrides):
                      insecure=True, cmd=urlcmd, vmport=disconnected_vmport)
         disconnected_url = os.popen(urlcmd).read().strip()
         data['disconnected_url'] = disconnected_url
-    feature_gates = data['feature_gates']
-    if feature_gates:
-        data['feature_gates'] = [f"{feature_gate}=true" for feature_gate in feature_gates]
+    # Note: feature_gates is passed as-is to the template.
+    # The template handles formatting for both extraArgs (comma-separated key=true)
+    # and KubeletConfiguration featureGates (YAML map with key: true)
     result = config.plan(plan, inputfile=f'{plandir}/bootstrap.yml', overrides=data)
     if result['result'] != "success":
         return result

--- a/kvirt/cluster/kubeadm/config_bootstrap.yaml
+++ b/kvirt/cluster/kubeadm/config_bootstrap.yaml
@@ -65,22 +65,22 @@ proxy:
 apiServer:
   certSANs:
   - {{ api_fqdn }}
-{% if feature_gates %}
+{% if feature_gates or runtime_config %}
   extraArgs:
 {% if runtime_config %}
-  - name: "runtime-config"
-    value: "{{ runtime_config_string|join(',') }}"
+    runtime-config: "{{ runtime_config_string|join(',') }}"
 {% endif %}
-  - name: "feature-gates"
-    value: "{{ feature_gates_string|join(',') }}"
+{% if feature_gates %}
+    feature-gates: "{{ feature_gates_string|join(',') }}"
+{% endif %}
+{% endif %}
+{% if feature_gates %}
 controllerManager:
   extraArgs:
-  - name: "feature-gates"
-    value: "{{ feature_gates_string|join(',') }}"
+    feature-gates: "{{ feature_gates_string|join(',') }}"
 scheduler:
   extraArgs:
-  - name: "feature-gates"
-    value: "{{ feature_gates_string|join(',') }}"
+    feature-gates: "{{ feature_gates_string|join(',') }}"
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 cgroupDriver: systemd


### PR DESCRIPTION
The kubeadm v1beta3 API expects extraArgs as a map (key: value) not an array of objects (name/value). This was causing cluster creation to fail with: "json: cannot unmarshal array into Go struct field APIServer.apiServer.extraArgs of type map[string]string"

Changes:
- config_bootstrap.yaml: Use map format for extraArgs instead of array
- __init__.py: Remove premature "=true" append since template handles it