### PR TITLE
vsphere: add extra_iso support for second CDROM

### DIFF
--- a/kvirt/extra_keywords/vsphere.yml
+++ b/kvirt/extra_keywords/vsphere.yml
@@ -1,4 +1,5 @@
 antipeers: Create anti affinity rules between members
+extra_iso: Extra ISO to plug as second CDROM (same semantics as KVM)
 distributed: Use dvs networks
 force_pool: Relocate vn from one pool to another
 serial: Inject a serial console

--- a/kvirt/providers/vsphere/helpers.py
+++ b/kvirt/providers/vsphere/helpers.py
@@ -263,7 +263,7 @@ def createcdspec():
     return cdspec
 
 
-def createisospec(iso=None):
+def createisospec(iso=None, unit_number=0, controller_key=201, device_key=-1):
     cdspec = vim.vm.device.VirtualDeviceSpec()
     cdspec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
     connect = vim.vm.device.VirtualDevice.ConnectInfo()
@@ -276,9 +276,9 @@ def createisospec(iso=None):
     if iso is not None:
         cdbacking.fileName = iso
     cd.backing = cdbacking
-    cd.controllerKey = 201
-    cd.unitNumber = 0
-    cd.key = -1
+    cd.controllerKey = controller_key
+    cd.unitNumber = unit_number
+    cd.key = device_key
     cdspec.device = cd
     return cdspec
 


### PR DESCRIPTION
Allow attaching a second ISO to a VM via overrides['extra_iso'], matching KVM behavior. Uses the other IDE controller (200) and a distinct device key (-2) so vSphere accepts multiple new devices in one ReconfigSpec. info() also exposes the second CD as extra_iso.