### PR TITLE
fix: replace bare except clauses with except Exception

### DIFF
--- a/kvirt/expose/__init__.py
+++ b/kvirt/expose/__init__.py
@@ -25,7 +25,7 @@ class Kexposer():
             plan = search.group(1)
             try:
                 fileoverrides = get_overrides(paramfile=paramfile)
-            except:
+            except Exception:
                 continue
             if 'owner' in fileoverrides:
                 owners[plan] = fileoverrides['owner']
@@ -104,7 +104,7 @@ class Kexposer():
                 if pfdata is not None:
                     try:
                         new_parameters = yaml.safe_load(pfdata)
-                    except:
+                    except Exception:
                         new_parameters = {}
                     new_parameters.update(parameters)
                     parameters = new_parameters
@@ -213,7 +213,7 @@ class Kexposer():
                 if pfdata is not None:
                     try:
                         new_parameters = yaml.safe_load(pfdata)
-                    except:
+                    except Exception:
                         new_parameters = {}
                     new_parameters.update(parameters)
                     parameters = new_parameters


### PR DESCRIPTION
## Summary

Replace 3 bare `except:` clauses with `except Exception:` in `kvirt/expose/__init__.py` (PEP 8 E722).

**Why:** Bare `except:` catches all exceptions including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`. Since these blocks handle parse/load failures as fallbacks (not re-raising), `except Exception:` is the correct scope.

**Changes:**
```python
# Before (lines 28, 107, 216)
except:
    continue  # or fallback assignment

# After
except Exception:
    continue  # or fallback assignment
```

## Testing
No behavior change for normal operation — only prevents accidentally swallowing system-level exceptions.