### PR TITLE
kweb: fix DELETE /vms/{name} crash when provider lacks keep_disks

### DIFF
--- a/kvirt/web/__init__.py
+++ b/kvirt/web/__init__.py
@@ -2,6 +2,7 @@
 
 from ast import literal_eval
 import functools
+import inspect
 from kvirt.bottle import Bottle, request, static_file, jinja2_view, response, redirect
 from kvirt.config import Kconfig
 from kvirt.common import print_info, get_free_port, get_parameters, delete_lastvm
@@ -420,7 +421,10 @@ class Kweb():
             data = request.json or request.forms
             snapshots = data is not None and 'snapshots' in data and bool(data['snapshots'])
             keep_disks = data is not None and 'keep_disks' in data and bool(data['keep_disks'])
-            result = k.delete(name, snapshots=snapshots, keep_disks=keep_disks)
+            delete_kwargs = {'snapshots': snapshots}
+            if 'keep_disks' in inspect.signature(k.delete).parameters:
+                delete_kwargs['keep_disks'] = keep_disks
+            result = k.delete(name, **delete_kwargs)
             delete_lastvm(name, config.client)
             response.status = 200
             return result


### PR DESCRIPTION
## Summary

- The `vmdelete` handler in kweb unconditionally passes `keep_disks` to `k.delete()`, but only 2 of 13 providers (GCP and sampleprovider) accept that parameter
- All other providers — including KVM/libvirt, AWS, Azure, KubeVirt, oVirt, Proxmox, vSphere, etc. — raise `TypeError: delete() got an unexpected keyword argument 'keep_disks'`, which Bottle catches and returns as an HTML 500 error
- This fix checks the provider's `delete()` signature via `inspect.signature()` before passing `keep_disks`, so the parameter is only forwarded to providers that support it

Fixes #863

## How to reproduce

```bash
kweb --port 8000
kcli create vm -i fedora41 test-vm
curl -X DELETE http://localhost:8000/vms/test-vm  # → 500
```

## After this fix

```bash
curl -X DELETE http://localhost:8000/vms/test-vm  # → 200 {"result": "success"}
```

Made with [Cursor](https://cursor.com)