### PR TITLE
kubeadm: align CRI-O engine_version URL handling

### DIFF
--- a/kvirt/cluster/kubeadm/__init__.py
+++ b/kvirt/cluster/kubeadm/__init__.py
@@ -204,6 +204,7 @@ def create(config, plandir, cluster, overrides):
         engine_version = data['engine_version'] or kube_version
         if not engine_version.startswith('v'):
             engine_version = f'v{engine_version}'
+        data['engine_version'] = engine_version
         engine_url = f"https://download.opensuse.org/repositories/isv:/cri-o:/stable:/{engine_version}/rpm/repodata/repomd.xml"
         try:
             urlopen(engine_url)

--- a/kvirt/cluster/kubeadm/crio-d.sh
+++ b/kvirt/cluster/kubeadm/crio-d.sh
@@ -3,13 +3,13 @@ VERSION={{ version or "$(curl -L -s https://dl.k8s.io/release/stable.txt)" }}
 VERSION=$(echo "v${VERSION#v}" | cut -d. -f1,2)
 
 {% if ubuntu|default(False) %}
-PROJECT_PATH={{ engine_version or 'stable:/$VERSION' }}
+PROJECT_PATH=stable:/{{ engine_version or '$VERSION' }}
 curl -fsSL https://download.opensuse.org/repositories/isv:/cri-o:/$PROJECT_PATH/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg
 echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://download.opensuse.org/repositories/isv:/cri-o:/$PROJECT_PATH/deb/ /" > /etc/apt/sources.list.d/cri-o.list
 apt-get update
 apt-get -y install cri-o runc software-properties-common
 {% else %}
-PROJECT_PATH={{ engine_version or 'stable:/$VERSION' }}
+PROJECT_PATH=stable:/{{ engine_version or '$VERSION' }}
 echo """[cri-o]
 name=CRI-O
 baseurl=https://download.opensuse.org/repositories/isv:/cri-o:/$PROJECT_PATH/rpm


### PR DESCRIPTION
Normalize and persist engine_version in kubeadm config rendering so
validation and bootstrap use the same CRI-O path semantics.
This prevents valid pinned versions from passing precheck but failing 
at node bootstrap with a mismatched repository URL.
