### PR TITLE
Fix aarch64 ISO handling in generate_rhcos_iso

### DIFF
--- a/.github/macosx.sh
+++ b/.github/macosx.sh
@@ -1,0 +1,5 @@
+bash extras/build_macos_pkg.sh
+
+echo pushing kcli.pkg
+pip install --break-system-packages cloudsmith-cli
+cloudsmith push raw karmab/kcli kcli.pkg

--- a/.github/workflows/macosx-weekly.yml
+++ b/.github/workflows/macosx-weekly.yml
@@ -1,0 +1,21 @@
+name: SNAPSHOT-MACOSX-DAILY
+on:
+  schedule:
+    - cron: '39 20 * * 0'
+
+env:
+ CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+ PYTHONUNBUFFERED: true
+
+jobs:
+
+  run-workflow:
+    name: Workflow
+    runs-on: macos-26
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - if: github.ref == 'refs/heads/main' && github.repository_owner == 'karmab'
+        name: Create MACOSX pkg
+        run: |
+          .github/macosx.sh

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -1,0 +1,21 @@
+name: MACOSX-PKG
+
+on:
+  workflow_dispatch:
+
+env:
+ CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+ PYTHONUNBUFFERED: true
+
+jobs:
+
+  run-workflow:
+    name: Workflow
+    runs-on: macos-26
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - if: github.ref == 'refs/heads/main' && github.repository_owner == 'karmab'
+        name: Create MACOSX pkg
+        run: |
+          .github/macosx.sh

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ kvirt/static/reports/*
 venv*
 .idea
 openshift_pull.json
+*.pkg

--- a/extras/build_macos_pkg.sh
+++ b/extras/build_macos_pkg.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -e
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;36m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+MACOS_DIR="$SCRIPT_DIR/macos"
+VERSION="${GIT_CUSTOM_VERSION:-99.0.$(date +%Y%m%d%H%M).$(git -C "$REPO_DIR" rev-parse --short HEAD | python3 -c "import sys; print(int(sys.stdin.read().strip(), 16))")}"
+STAGING=$(mktemp -d)
+INSTALL_DIR="$STAGING/usr/local/kcli"
+BIN_DIR="$STAGING/usr/local/bin"
+
+trap "rm -rf $STAGING" EXIT
+
+echo -e "${BLUE}Building kcli macOS package...${NC}"
+
+if [ "$(uname -s)" != "Darwin" ]; then
+    echo -e "${RED}This script must be run on macOS${NC}"
+    exit 1
+fi
+
+if ! which python3 >/dev/null 2>&1; then
+    echo -e "${RED}python3 not found. Install Xcode Command Line Tools: xcode-select --install${NC}"
+    exit 1
+fi
+
+echo -e "${BLUE}Creating virtualenv...${NC}"
+python3 -m venv "$INSTALL_DIR"
+
+echo -e "${BLUE}Installing kcli...${NC}"
+SRC_DIR="$STAGING/src"
+cp -a "$REPO_DIR" "$SRC_DIR"
+/usr/bin/sed -i "" "s/, 'libvirt-python>=2.0.0'//" "${SRC_DIR}/setup.py"
+"$INSTALL_DIR/bin/pip" install --no-cache-dir "$SRC_DIR" 2>&1 | tail -1
+rm -rf "$SRC_DIR"
+
+mkdir -p "$BIN_DIR"
+cat > "$BIN_DIR/kcli" << 'WRAPPER'
+#!/bin/bash
+exec /usr/local/kcli/bin/kcli "$@"
+WRAPPER
+chmod +x "$BIN_DIR/kcli"
+
+echo -e "${BLUE}Building .pkg...${NC}"
+CORE_PKG="$STAGING/kcli-core.pkg"
+pkgbuild --root "$STAGING" \
+         --identifier com.karmab.kcli \
+         --version "$VERSION" \
+         --install-location / \
+         "$CORE_PKG"
+
+RESOURCES="$STAGING/resources"
+mkdir -p "$RESOURCES"
+sed "s/@@VERSION@@/$VERSION/" "$MACOS_DIR/resources/welcome.html" > "$RESOURCES/welcome.html"
+cp "$REPO_DIR/kcli.png" "$RESOURCES/background.png"
+
+productbuild --distribution "$MACOS_DIR/Distribution" \
+             --resources "$RESOURCES" \
+             --package-path "$STAGING" \
+             "$REPO_DIR/kcli.pkg"
+
+echo -e "${GREEN}Built kcli.pkg${NC}"
+echo -e "${BLUE}Install with: open kcli.pkg${NC}"

--- a/extras/macos/Distribution
+++ b/extras/macos/Distribution
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<installer-gui-script minSpecVersion="2">
+    <title>kcli</title>
+    <background file="background.png" alignment="bottomleft" scaling="proportional"/>
+    <welcome file="welcome.html"/>
+    <options customize="never" require-scripts="false"/>
+    <domains enable_localSystem="true"/>
+    <choices-outline>
+        <line choice="default">
+            <line choice="com.karmab.kcli"/>
+        </line>
+    </choices-outline>
+    <choice id="default"/>
+    <choice id="com.karmab.kcli" visible="false">
+        <pkg-ref id="com.karmab.kcli"/>
+    </choice>
+    <pkg-ref id="com.karmab.kcli" version="99.0" onConclusion="none">kcli-core.pkg</pkg-ref>
+</installer-gui-script>

--- a/extras/macos/resources/welcome.html
+++ b/extras/macos/resources/welcome.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+<h2>kcli @@VERSION@@</h2>
+<p>This package installs <b>kcli</b>, a tool for managing virtual machines across multiple providers including UTM, Libvirt, AWS, GCP, Azure, Kubevirt, and more.</p>
+<p>On macOS, kcli works with <b>UTM</b> to create and manage local virtual machines. Make sure UTM is installed from <a href="https://mac.getutm.app">mac.getutm.app</a>.</p>
+<p>After installation, run <code>kcli</code> from any terminal.</p>
+</body>
+</html>

--- a/kvirt/common/__init__.py
+++ b/kvirt/common/__init__.py
@@ -1290,20 +1290,24 @@ def get_installer_rhcos(_type='kvm', region=None, arch='x86_64'):
         return data['architectures'][arch]['artifacts'][key]['formats'][_format]['disk']['location']
 
 
-def get_installer_iso():
+def get_installer_iso(arch=None):
     os.environ["PATH"] += f":{os.getcwd()}"
     if which('openshift-install') is None:
         error("Couldnt find openshift-install in your path")
         sys.exit(0)
+    if arch is None:
+        arch = os.uname().machine
     INSTALLER_COREOS = os.popen('openshift-install coreos print-stream-json 2>/dev/null').read()
     data = json.loads(INSTALLER_COREOS)
-    return data['architectures']['x86_64']['artifacts']['metal']['formats']['iso']['disk']['location']
+    return data['architectures'][arch]['artifacts']['metal']['formats']['iso']['disk']['location']
 
 
-def get_installer_iso_sha():
+def get_installer_iso_sha(arch=None):
+    if arch is None:
+        arch = os.uname().machine
     INSTALLER_COREOS = os.popen('openshift-install coreos print-stream-json 2>/dev/null').read()
     data = json.loads(INSTALLER_COREOS)
-    return data['architectures']['x86_64']['artifacts']['metal']['formats']['iso']['disk']['sha256']
+    return data['architectures'][arch]['artifacts']['metal']['formats']['iso']['disk']['sha256']
 
 
 def get_latest_rhcos_metal(url):
@@ -1934,9 +1938,10 @@ def filter_compression_extension(name):
 
 def generate_rhcos_iso(k, cluster, pool, version='latest', installer=False, arch='x86_64', extra_args=None, url=None):
     if url is not None:
+        baseiso = os.path.basename(url)
         liveiso = url
     elif installer:
-        liveiso = get_installer_iso()
+        liveiso = get_installer_iso(arch=arch)
         baseiso = os.path.basename(liveiso)
     else:
         baseiso = f'rhcos-live.{arch}.iso'
@@ -1977,8 +1982,8 @@ def generate_rhcos_iso(k, cluster, pool, version='latest', installer=False, arch
         k.add_image(liveiso, pool)
     poolpath = k.get_pool_path(pool)
     os.environ["PATH"] += f":{os.getcwd()}"
-    if installer and (k.conn == 'fake' or k.host in ['localhost', '127.0.0.1']):
-        if not correct_sha(f"{poolpath}/{baseiso}", get_installer_iso_sha()):
+    if url is None and installer and (k.conn == 'fake' or k.host in ['localhost', '127.0.0.1']):
+        if not correct_sha(f"{poolpath}/{baseiso}", get_installer_iso_sha(arch=arch)):
             error(f"Corrupted iso {poolpath}/{baseiso}")
             sys.exit(1)
     pprint(f"Creating iso {name}")


### PR DESCRIPTION
## Summary

Three bugs in `generate_rhcos_iso` (and its helpers) prevented SNO deployment on aarch64 hosts:

- **`get_installer_iso()` / `get_installer_iso_sha()` hardcode `x86_64`**: Both functions used `data['architectures']['x86_64']` to look up the ISO URL and SHA from the coreos stream JSON. On aarch64 hosts this returned the wrong ISO. Fixed by adding an optional `arch` parameter that defaults to `os.uname().machine`.

- **`baseiso` uninitialized when custom URL provided**: When `generate_rhcos_iso()` receives a `url` parameter (via `liveiso_url`), only `liveiso` was set. The `baseiso` variable was left undefined, causing an `UnboundLocalError` on the subsequent `if baseiso not in pool_isos_names` check. Fixed by setting `baseiso = os.path.basename(url)`.

- **SHA check fails for custom ISO URLs**: The SHA integrity check compared any downloaded ISO against the SHA of the installer-bundled ISO (a different file). When using `liveiso_url` with an aarch64 ISO, this always reported "Corrupted iso" and aborted. Fixed by skipping the check when a custom `url` is provided, and forwarding `arch` to `get_installer_iso_sha()` for the non-URL path.

## How to reproduce

On an aarch64 host with libvirt:

```yaml
# sno-params.yml
sno: true
sno_vm: true
tag: '4.21'
version: stable
memory: 32768
numcpus: 16
disk_size: 120
network: default
pull_secret: /root/.kcli/openshift_pull.json
```

```bash
kcli create cluster openshift --pf sno-params.yml sno
```

**Before fix:** Fails with `UnboundLocalError: cannot access local variable 'baseiso'` or downloads the x86_64 ISO and reports "Corrupted iso".

**After fix:** Downloads the correct aarch64 ISO and deploys successfully.

## Test plan

- [x] Verified SNO deployment on aarch64 (ARM64 Apollo machine, OCP 4.21)
- [x] All changes are backward-compatible (`arch` defaults to host architecture, existing x86_64 behavior unchanged)


Made with [Cursor](https://cursor.com)