### PR TITLE
fix(hcloud): fail fast when orphan volume exists instead of crashing …

### DIFF
--- a/kvirt/providers/hcloud/__init__.py
+++ b/kvirt/providers/hcloud/__init__.py
@@ -139,10 +139,23 @@ class Khcloud():
                             disksize = disk.get('size', '10')
 
                         diskname = f"{name}-disk{index}"
-                        volumeresponse = self.conn.volumes.get_by_name(diskname)
-                        if volumeresponse is None:
-                            volumeresponse = self.conn.volumes.create(disksize, diskname, location=location,
-                                                                      labels={"kcli-managed": "volume"})
+                        existing_volume = self.conn.volumes.get_by_name(diskname)
+                        if existing_volume is not None:
+                            attached = (f"attached to server {existing_volume.server.name!r}"
+                                        if existing_volume.server is not None
+                                        else "detached (orphan)")
+                            reason = (
+                                f"hcloud volume {diskname!r} already exists and is {attached}. "
+                                f"This usually means a previous create for {name!r} failed and "
+                                f"left a volume behind. Refusing to silently reuse it. "
+                                f"Remove it (e.g. `kcli delete disk -n -y {diskname}` or "
+                                f"`hcloud volume delete {diskname}`) and retry."
+                            )
+                            return {'result': 'failure', 'reason': reason}
+                        volumeresponse = self.conn.volumes.create(
+                            disksize, diskname, location=location,
+                            labels={"kcli-managed": "volume"},
+                        )
                         volumeresponses.append(volumeresponse)
 
                     created_vm.action.wait_until_finished(300)


### PR DESCRIPTION
…with AttributeError

When a VM create fails after volumes are created but before the VM finishes booting, the volumes remain as orphans in the hcloud project. On retry, the previous code would silently accept these orphans as if they were newly-created, then crash deep in the attach loop with:
  AttributeError: 'Volume' object has no attribute 'action'

This was because volumes.get_by_name() and volumes.create() return different SDK types:
  - get_by_name() returns a BoundVolume (Volume), which has no .action
  - create() returns a CreateVolumeResponse, which has both .action and .volume

Additionally, silently reusing an orphan volume is unsafe: it could attach a stranger's data disk to the new VM in automation pipelines.

This fix makes the orphan case fail fast with a single, actionable error message naming the volume and explaining how to remove it, instead of crashing inside the attach loop with a confusing traceback.