### PR TITLE
Add: Image for Ubuntu 26.04 (Resolute Racoon)

### DIFF
--- a/kvirt/defaults.py
+++ b/kvirt/defaults.py
@@ -110,6 +110,7 @@ IMAGES = {'almalinux8': f'{ALMA}/8/cloud/x86_64/images/AlmaLinux-8-GenericCloud-
           'ubuntu2410': f'{UBUNTU}/24.10/release/ubuntu-24.10-server-cloudimg-amd64.img',
           'ubuntu2504': f'{UBUNTU}/24.04/release/ubuntu-25.04-server-cloudimg-amd64.img',
           'ubuntu2510': f'{UBUNTU}/24.10/release/ubuntu-25.10-server-cloudimg-amd64.img'}
+          'ubuntu2604': f'{UBUNTU}/26.04/release/ubuntu-26.04-server-cloudimg-amd64.img'}
 
 IMAGESCOMMANDS = {'debian8': 'echo datasource_list: [NoCloud, ConfigDrive, Openstack, Ec2] > /etc/cloud/cloud.cfg.d/'
                   '90_dpkg.cfg'}


### PR DESCRIPTION
Hi @karmab,

I would like to contribute the addtion of the Ubuntu 26.04 image to your project. I verified that the image behind the link is working with the following command:

~~~
kcli create vm -i https://cloud-images.ubuntu.com/releases/resolute/release/ubuntu-26.04-server-cloudimg-amd64.img myubuntu
~~~

After the VM was created I could login using `kcli ssh myubuntu` as usual.

Cheers,  
Tronde