### PR TITLE
Add and Fix: Add OpenSUSE Leap 16 and fix some typo

### DIFF
--- a/kvirt/defaults.py
+++ b/kvirt/defaults.py
@@ -109,7 +109,7 @@ IMAGES = {'almalinux8': f'{ALMA}/8/cloud/x86_64/images/AlmaLinux-8-GenericCloud-
           'ubuntu2404': f'{UBUNTU}/24.04/release/ubuntu-24.04-server-cloudimg-amd64.img',
           'ubuntu2410': f'{UBUNTU}/24.10/release/ubuntu-24.10-server-cloudimg-amd64.img',
           'ubuntu2504': f'{UBUNTU}/24.04/release/ubuntu-25.04-server-cloudimg-amd64.img',
-          'ubuntu2510': f'{UBUNTU}/24.10/release/ubuntu-25.10-server-cloudimg-amd64.img',
+          'ubuntu2510': f'{UBUNTU}/25.10/release/ubuntu-25.10-server-cloudimg-amd64.img',
           'ubuntu2604': f'{UBUNTU}/26.04/release/ubuntu-26.04-server-cloudimg-amd64.img'}
 
 IMAGESCOMMANDS = {'debian8': 'echo datasource_list: [NoCloud, ConfigDrive, Openstack, Ec2] > /etc/cloud/cloud.cfg.d/'

--- a/kvirt/defaults.py
+++ b/kvirt/defaults.py
@@ -81,6 +81,7 @@ IMAGES = {'almalinux8': f'{ALMA}/8/cloud/x86_64/images/AlmaLinux-8-GenericCloud-
           'openeuler2409': f'{EULER}-24.09/virtual_machine_img/x86_64/openEuler-24.09-x86_64.qcow2.xz',
           'opensuse155': f'{SUSE}/repositories/Cloud:/Images:/Leap_15.5/images/openSUSE-Leap-15.5.x86_64-NoCloud.qcow2',
           'opensuse156': f'{SUSE}/repositories/Cloud:/Images:/Leap_15.6/images/openSUSE-Leap-15.6.x86_64-NoCloud.qcow2',
+          'opensuse160': f'{SUSE}/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-Cloud.qcow2',
           'rhcos410': f'{RHCOS}/4.10',
           'rhcos411': f'{RHCOS}/4.11',
           'rhcos412': f'{RHCOS}/4.12',


### PR DESCRIPTION
Hi @karmab.

- In [4e508db](4e508db2fa91bacbb7708eb02d2933cefa12bf4a) I fixed a typo for Ubuntu 25.10
- With [34abcf2](34abcf20b8a8d71faf78036caee754f61a107fba) I like to add OpenSUSE Leap 16.0 to the images list

I verified the OpenSUSE image by running the commands from the following code block:

~~~
$ kcli create vm -i https://download.opensuse.org/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-Cloud.qcow2 leap1

$ cat .kcli/profiles.yml 
myleap:
  image: https://download.opensuse.org/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-Cloud.qcow2
  vmuser: alice
  keys:
    - /home/alice/.ssh/alice_ed25519.pub

$ kcli create vm -p myleap leap2
~~~

Image was provisioned and usable as expected.

Best regards,
Joerg