### PR TITLE
openshift: fix tag trailing zero for X.0 versions

### DIFF
--- a/kvirt/cluster/openshift/__init__.py
+++ b/kvirt/cluster/openshift/__init__.py
@@ -796,8 +796,9 @@ def create(config, plandir, cluster, overrides, dnsconfig=None):
     version = data['version']
     tag = data['tag']
     if isinstance(tag, float) and str(tag).count('.') == 1 and len(str(tag).split('.')[1]) == 1:
-        tag = f'{tag}0'
-        data['tag'] = tag
+        if str(tag).split('.')[1] != '0':
+            tag = f'{tag}0'
+            data['tag'] = tag
     version = overrides.get('version') or detect_openshift_version(tag, OPENSHIFT_TAG)
     data['version'] = version
     if os.path.exists('coreos-installer'):


### PR DESCRIPTION
When YAML parses a tag like 5.0, it becomes the float 5.0.
The existing code appends a trailing zero to single-digit minor
versions (e.g. 4.1 -> 4.10) since YAML strips the trailing zero.
However, this incorrectly converts 5.0 to 5.00, causing URL
lookups to fail with:

Couldn't open url https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp-dev-preview/candidate-5.00/release.txt

Skip the trailing zero append when the minor version is 0, since
X.0 is a valid version and X.00 does not exist.

Signed-off-by: Sebastian Sch <sebassch@gmail.com>