### PR TITLE
Add client option to klist.py for Ansible inventory.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2404,6 +2404,19 @@ klist.py is provided as a dynamic inventory for ansible.
 
 The script uses sames conf as kcli (and as such defaults to local if no configuration file is found).
 
+You can target a specific client with `-c`, `-C` or `--client`, as with the main kcli command:
+
+```Shell
+klist.py -c myremote --list
+```
+
+Ansible only passes `--list` or `--host` to inventory scripts, so to use a non-default client with ansible, create a thin wrapper:
+
+```
+#!/bin/bash
+exec klist.py -c myremote "$@"
+```
+
 vms will be grouped by plan, or put in the kvirt group if they dont belong to any plan.
 
 Try it with:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2551,6 +2551,19 @@ klist.py is provided as a dynamic inventory for ansible.
 
 The script uses sames conf as kcli (and as such defaults to local if no configuration file is found).
 
+You can target a specific client with ``-c``, ``-C`` or ``--client``, as with the main kcli command:
+
+.. code:: shell
+
+   klist.py -c myremote --list
+
+Ansible only passes ``--list`` or ``--host`` to inventory scripts, so to use a non-default client with ansible, create a thin wrapper:
+
+::
+
+   #!/bin/bash
+   exec klist.py -c myremote "$@"
+
 vms will be grouped by plan, or put in the kvirt group if they dont belong to any plan.
 
 Try it with:

--- a/kvirt/klist.py
+++ b/kvirt/klist.py
@@ -16,7 +16,7 @@ class KcliInventory(object):
     def __init__(self):
         self.inventory = {}
         self.read_cli_args()
-        config = Kconfig(quiet=True)
+        config = Kconfig(client=self.args.client, quiet=True)
         self.host = config.host
         self.port = config.port
         self.user = config.user
@@ -40,6 +40,7 @@ class KcliInventory(object):
     # Read the command line args passed to the script.
     def read_cli_args(self):
         parser = argparse.ArgumentParser()
+        parser.add_argument('-C', '-c', '--client', help='Client to use')
         parser.add_argument('--list', action='store_true')
         parser.add_argument('--host', action='store')
         self.args = parser.parse_args()


### PR DESCRIPTION
Allow selecting a kcli client with -C, -c, or --client, matching the main CLI.

I added this to have an easy way to generate a dynamic ansible inventory from a remote client. To use it as an dynamic ansible inventory when using the client option you need to wrap it like this:

~~~
#!/bin/bash
exec klist.py -c myremote "$@"
~~~

The wrapper can be called with `wrapper.sh --list` and returns the inventory as `kcli.py --list` would do for the local client. This enables me to run ansible commands and playbooks from my workstation against VMs running on a remote libvirt hypervisor.

I tested and verified this manually in my environment. I would appreciate it, if you can review this PR and merge it, if you find it useful.

Plesae provide feedback if your find something that's off and that can be improved.

Cheers,  
Joerg