### PR TITLE
Fix OKD release override on cross-architecture KVM

### DIFF
--- a/kvirt/cluster/openshift/__init__.py
+++ b/kvirt/cluster/openshift/__init__.py
@@ -1048,7 +1048,7 @@ def create(config, plandir, cluster, overrides, dnsconfig=None):
             msg = f"Missing {image}. Indicate correct image in your parameters file..."
             return {'result': 'failure', 'reason': msg}
     base_url = 'quay.io/okd/scos-release' if okd else 'quay.io/openshift-release-dev/ocp-release'
-    if provider in virt_providers and platform.machine() != arch:
+    if provider in virt_providers and platform.machine() != arch and not okd:
         pprint(f"Forcing release image to {arch}")
         os.environ['OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE'] = f'{base_url}:{INSTALLER_VERSION}-{arch}'
     elif provider in cloud_providers and platform.machine() != 'x86_64':


### PR DESCRIPTION
## Summary

Skip the cross-architecture release image override for OKD on virtualized providers while preserving the existing behavior for OCP.

## Issue
Fixes #882

## Problem

When an arm64 client controls a remote x86_64 KVM host, kcli appends the target architecture to the OKD SCOS release tag. This produces a nonexistent image such as `quay.io/okd/scos-release:4.21.0-okd-scos.11-x86_64`, causing `manifest unknown` during `node-image-pull`.

## Fix

Do not set the architecture-suffixed release override for OKD. The installer then uses the valid OKD release tag without the `-x86_64` suffix.

## Validation

An OKD 4.21 installation using this change completed successfully through `Install complete!`.
